### PR TITLE
Use SessionSettings#reapply instead of Load#reapply

### DIFF
--- a/extractor/src/main/scala/org/jetbrains/sbt/CreateTasks.scala
+++ b/extractor/src/main/scala/org/jetbrains/sbt/CreateTasks.scala
@@ -57,7 +57,6 @@ object CreateTasks extends (State => State) with SbtStateOps {
     val transformedProjectSettings = extractedStructure.allProjectRefs.flatMap { projectRef =>
       Load.transformSettings(Load.projectScope(projectRef), projectRef.build, rootProject, projectSettings)
     }
-    val newStructure = Load.reapply(session.mergeSettings ++ transformedGlobalSettings ++ transformedProjectSettings, extractedStructure)
-    Project.setProject(session, newStructure, state)
+    SessionSettings.reapply(extracted.session.appendRaw(transformedGlobalSettings ++ transformedProjectSettings), state)
   }
 }


### PR DESCRIPTION
Fixes [SCL-10322](https://youtrack.jetbrains.com/issue/SCL-10322). Before the commit, sbt-structure calls directly `Load#reapply` when it must also '[re-inject a settings logger](https://github.com/sbt/sbt/blob/1.0.x/main/src/main/scala/sbt/Main.scala#L246)', because the logger [tied with `State` oject](https://github.com/sbt/sbt/blob/1.0.x/main/src/main/scala/sbt/LogManager.scala#L111) object via `WeakReference` and the old one just will be collected by gc, so any logging via `sLog` key after will cause "_Settings logger used after project was loaded_" error. For now we are calling `SessionSettings#reapply` which already does all these things. I hope I understood the things correctly. 