### PR TITLE
Add aar support when importing sbt-android

### DIFF
--- a/extractor/src/main/scala/org/jetbrains/sbt/CreateTasks.scala
+++ b/extractor/src/main/scala/org/jetbrains/sbt/CreateTasks.scala
@@ -18,7 +18,7 @@ object CreateTasks extends (State => State) with SbtStateOps {
         UtilityTasks.acceptedProjects,
       StructureKeys.extractProjects <<=
         (Keys.state, StructureKeys.acceptedProjects) flatMap { (state, acceptedProjects) =>
-          StructureKeys.extractProject.forAllProjects(state, acceptedProjects).map(_.values.toSeq)
+          StructureKeys.extractProject.forAllProjects(state, acceptedProjects).map(_.values.toSeq.flatten)
         },
       StructureKeys.extractRepository <<=
         RepositoryExtractor.taskDef,

--- a/extractor/src/main/scala/org/jetbrains/sbt/StructureKeys.scala
+++ b/extractor/src/main/scala/org/jetbrains/sbt/StructureKeys.scala
@@ -18,7 +18,7 @@ object StructureKeys {
   lazy val extractAndroid         = TaskKey[Option[AndroidData]]("ss-extract-android")
   lazy val extractBuild           = TaskKey[BuildData]("ss-extract-build")
   lazy val extractDependencies    = TaskKey[DependencyData]("ss-extract-dependencies")
-  lazy val extractProject         = TaskKey[ProjectData]("ss-extract-project")
+  lazy val extractProject         = TaskKey[Seq[ProjectData]]("ss-extract-project")
   lazy val extractProjects        = TaskKey[Seq[ProjectData]]("ss-extract-projects")
   lazy val extractRepository      = TaskKey[Option[RepositoryData]]("ss-extract-repository")
 

--- a/shared/src/main/scala/org/jetbrains/sbt/structure/data.scala
+++ b/shared/src/main/scala/org/jetbrains/sbt/structure/data.scala
@@ -164,7 +164,10 @@ case class AndroidData(targetVersion: String,
                        libs: File,
                        isLibrary: Boolean,
                        proguardConfig: Seq[String],
-                       apklibs: Seq[ApkLib])
+                       apklibs: Seq[ApkLib],
+                       aars: Seq[Aar])
+
+case class Aar(name: String, project: ProjectData)
 
 /**
  * Information about certain apklib used in Android project

--- a/shared/src/main/scala/org/jetbrains/sbt/structure/dataSerializers.scala
+++ b/shared/src/main/scala/org/jetbrains/sbt/structure/dataSerializers.scala
@@ -298,7 +298,7 @@ trait DataSerializers {
       val apklibs         = (what \ "apkLib").deserialize[ApkLib]
       Right(AndroidData(version, file(manifestPath), file(apkPath),
         file(resPath), file(assetsPath), file(genPath),
-        file(libsPath), isLibrary, proguardConfig, apklibs))
+        file(libsPath), isLibrary, proguardConfig, apklibs, Nil))
     }
   }
 


### PR DESCRIPTION
Implemented by:

* change `extractProject` to return `Seq[ProjectData]`
* adding a new `Aar` data type which contains a synthetic `ProjectData` which contains synthetic `AndroidData` for the aar module
* inspecting the `aars` task in sbt-android and mapping aar values to the `Aar` data type
* when running `extractProject` inspect `android` for any `aar` values and expand them to a list