### PR TITLE
SCL-13600 - Change the project id to guarantee its uniqueness

### DIFF
--- a/extractor/src/main/scala-sbt-0.12/org/jetbrains/sbt/extractors/DependenciesExtractor.scala
+++ b/extractor/src/main/scala-sbt-0.12/org/jetbrains/sbt/extractors/DependenciesExtractor.scala
@@ -25,7 +25,7 @@ class DependenciesExtractor(projectRef: ProjectRef,
   private def projectDependencies: Seq[ProjectDependencyData] =
     buildDependencies.classpath.getOrElse(projectRef, Seq.empty).map { it =>
       val configurations = it.configuration.map(jb.Configuration.fromString).getOrElse(Seq.empty)
-      ProjectDependencyData(it.project.id, configurations)
+      ProjectDependencyData(ExtractorUtils.extractId(it.project), configurations)
     }
 
   private def moduleDependencies: Seq[ModuleDependencyData] =

--- a/extractor/src/main/scala-sbt-0.12/org/jetbrains/sbt/extractors/ExtractorUtils.scala
+++ b/extractor/src/main/scala-sbt-0.12/org/jetbrains/sbt/extractors/ExtractorUtils.scala
@@ -1,0 +1,12 @@
+package org.jetbrains.sbt.extractors
+
+import sbt.ProjectRef
+
+/**
+  * @author Fernando Cappi
+  */
+object ExtractorUtils {
+  def extractId(projectRef: ProjectRef): String = {
+    projectRef.project + ":" + projectRef.build
+  }
+}

--- a/extractor/src/main/scala-sbt-0.12/org/jetbrains/sbt/extractors/ProjectExtractor.scala
+++ b/extractor/src/main/scala-sbt-0.12/org/jetbrains/sbt/extractors/ProjectExtractor.scala
@@ -43,7 +43,7 @@ class ProjectExtractor(projectRef: ProjectRef,
     }.toSet
     val configurations  =
       mergeConfigurations(sourceConfigurations.flatMap(extractConfiguration))
-    val projectData = ProjectData(projectRef.id, projectRef.build, name, organization, version, base,
+    val projectData = ProjectData(ExtractorUtils.extractId(projectRef), projectRef.build, name, organization, version, base,
       basePackages, target, build, configurations,
       extractJava, extractScala, android, dependencies, resolvers, play2,
       settings = Nil, // don't bother supporting this feature in sbt 0.12

--- a/extractor/src/main/scala-sbt-0.13-1.0/org/jetbrains/sbt/extractors/DependenciesExtractor.scala
+++ b/extractor/src/main/scala-sbt-0.13-1.0/org/jetbrains/sbt/extractors/DependenciesExtractor.scala
@@ -25,7 +25,7 @@ class DependenciesExtractor(projectRef: ProjectRef,
   private def projectDependencies: Seq[ProjectDependencyData] =
     buildDependencies.classpath.getOrElse(projectRef, Seq.empty).map { it =>
       val configurations = it.configuration.map(jb.Configuration.fromString).getOrElse(Seq.empty)
-      ProjectDependencyData(it.project.id, configurations)
+      ProjectDependencyData(ExtractorUtils.extractId(it.project), configurations)
     }
 
   private def moduleDependencies: Seq[ModuleDependencyData] =

--- a/extractor/src/main/scala-sbt-0.13-1.0/org/jetbrains/sbt/extractors/ExtractorUtils.scala
+++ b/extractor/src/main/scala-sbt-0.13-1.0/org/jetbrains/sbt/extractors/ExtractorUtils.scala
@@ -1,0 +1,12 @@
+package org.jetbrains.sbt.extractors
+
+import sbt.ProjectRef
+
+/**
+  * @author Fernando Cappi
+  */
+object ExtractorUtils {
+  def extractId(projectRef: ProjectRef): String = {
+    projectRef.project + ":" + projectRef.build
+  }
+}

--- a/extractor/src/main/scala-sbt-0.13-1.0/org/jetbrains/sbt/extractors/ProjectExtractor.scala
+++ b/extractor/src/main/scala-sbt-0.13-1.0/org/jetbrains/sbt/extractors/ProjectExtractor.scala
@@ -55,7 +55,7 @@ class ProjectExtractor(projectRef: ProjectRef,
           testConfigurations.flatMap(extractConfiguration(Test.name))
       )
     val projectData = ProjectData(
-      projectRef.id, projectRef.build, name, organization, version, base,
+      ExtractorUtils.extractId(projectRef), projectRef.build, name, organization, version, base,
       basePackages, target, build, configurations,
       extractJava, extractScala, android, dependencies, resolvers, play2,
       settingData, taskData, commandData)

--- a/extractor/src/test/data/0.12/bare/structure-0.12.4.xml
+++ b/extractor/src/test/data/0.12/bare/structure-0.12.4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.12.4">
   <project>
-    <id>bare</id>
+    <id>bare:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.12/dependency/structure-0.12.4.xml
+++ b/extractor/src/test/data/0.12/dependency/structure-0.12.4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.12.4">
   <project>
-    <id>dependency</id>
+    <id>dependency:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.12/multiple/structure-0.12.4.xml
+++ b/extractor/src/test/data/0.12/multiple/structure-0.12.4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.12.4">
   <project>
-    <id>root</id>
+    <id>root:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>
@@ -121,7 +121,7 @@
     <resolver name="public" root="http://repo1.maven.org/maven2/"></resolver>
   </project>
   <project>
-    <id>bar</id>
+    <id>bar:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>bar</name>
     <organization>bar</organization>
@@ -240,7 +240,7 @@
     <resolver name="public" root="http://repo1.maven.org/maven2/"></resolver>
   </project>
   <project>
-    <id>foo</id>
+    <id>foo:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>foo</name>
     <organization>foo</organization>

--- a/extractor/src/test/data/0.12/simple/structure-0.12.4.xml
+++ b/extractor/src/test/data/0.12/simple/structure-0.12.4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.12.4">
   <project>
-    <id>simple</id>
+    <id>simple:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/bare/structure-0.13.0.xml
+++ b/extractor/src/test/data/0.13/bare/structure-0.13.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.0">
   <project>
-    <id>bare</id>
+    <id>bare:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/bare/structure-0.13.13.xml
+++ b/extractor/src/test/data/0.13/bare/structure-0.13.13.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.13">
   <project>
-    <id>bare</id>
+    <id>bare:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/bare/structure-0.13.9.xml
+++ b/extractor/src/test/data/0.13/bare/structure-0.13.9.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.9">
   <project>
-    <id>bare</id>
+    <id>bare:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/classifiers/structure-0.13.0.xml
+++ b/extractor/src/test/data/0.13/classifiers/structure-0.13.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.0">
   <project>
-    <id>classifiers</id>
+    <id>classifiers:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>classifiers</name>
     <organization>default</organization>
@@ -1536,7 +1536,7 @@
     </command>
   </project>
   <project>
-    <id>bar</id>
+    <id>bar:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>bar</name>
     <organization>bar</organization>
@@ -3075,7 +3075,7 @@
     </command>
   </project>
   <project>
-    <id>foo</id>
+    <id>foo:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>foo</name>
     <organization>foo</organization>

--- a/extractor/src/test/data/0.13/classifiers/structure-0.13.13.xml
+++ b/extractor/src/test/data/0.13/classifiers/structure-0.13.13.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.13">
   <project>
-    <id>classifiers</id>
+    <id>classifiers:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>classifiers</name>
     <organization>default</organization>
@@ -1769,7 +1769,7 @@
     </command>
   </project>
   <project>
-    <id>bar</id>
+    <id>bar:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>bar</name>
     <organization>bar</organization>
@@ -3541,7 +3541,7 @@
     </command>
   </project>
   <project>
-    <id>foo</id>
+    <id>foo:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>foo</name>
     <organization>foo</organization>

--- a/extractor/src/test/data/0.13/classifiers/structure-0.13.9.xml
+++ b/extractor/src/test/data/0.13/classifiers/structure-0.13.9.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.9">
   <project>
-    <id>classifiers</id>
+    <id>classifiers:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>classifiers</name>
     <organization>default</organization>
@@ -1705,7 +1705,7 @@
     </command>
   </project>
   <project>
-    <id>bar</id>
+    <id>bar:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>bar</name>
     <organization>bar</organization>
@@ -3413,7 +3413,7 @@
     </command>
   </project>
   <project>
-    <id>foo</id>
+    <id>foo:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>foo</name>
     <organization>foo</organization>

--- a/extractor/src/test/data/0.13/custom-test-config/structure-0.13.0.xml
+++ b/extractor/src/test/data/0.13/custom-test-config/structure-0.13.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.0">
   <project>
-    <id>bare</id>
+    <id>bare:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/custom-test-config/structure-0.13.13.xml
+++ b/extractor/src/test/data/0.13/custom-test-config/structure-0.13.13.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.13">
   <project>
-    <id>bare</id>
+    <id>bare:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/custom-test-config/structure-0.13.9.xml
+++ b/extractor/src/test/data/0.13/custom-test-config/structure-0.13.9.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.9">
   <project>
-    <id>bare</id>
+    <id>bare:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/dependency/structure-0.13.0.xml
+++ b/extractor/src/test/data/0.13/dependency/structure-0.13.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.0">
   <project>
-    <id>dependency</id>
+    <id>dependency:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/dependency/structure-0.13.13.xml
+++ b/extractor/src/test/data/0.13/dependency/structure-0.13.13.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.13">
   <project>
-    <id>dependency</id>
+    <id>dependency:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/dependency/structure-0.13.9.xml
+++ b/extractor/src/test/data/0.13/dependency/structure-0.13.9.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.9">
   <project>
-    <id>dependency</id>
+    <id>dependency:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/dotty/structure-0.13.13.xml
+++ b/extractor/src/test/data/0.13/dotty/structure-0.13.13.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.13">
   <project>
-    <id>dotty</id>
+    <id>dotty:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/ide-settings/structure-0.13.13.xml
+++ b/extractor/src/test/data/0.13/ide-settings/structure-0.13.13.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.13">
   <project>
-    <id>ideSettings</id>
+    <id>ideSettings:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>
@@ -1789,7 +1789,7 @@
     </command>
   </project>
   <project>
-    <id>projectToRedirectOutput</id>
+    <id>projectToRedirectOutput:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>projectToRedirectOutput</name>
     <organization>projecttoredirectoutput</organization>

--- a/extractor/src/test/data/0.13/ide-settings/structure-0.13.9.xml
+++ b/extractor/src/test/data/0.13/ide-settings/structure-0.13.9.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.9">
   <project>
-    <id>ideSettings</id>
+    <id>ideSettings:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>
@@ -1733,7 +1733,7 @@
     </command>
   </project>
   <project>
-    <id>projectToRedirectOutput</id>
+    <id>projectToRedirectOutput:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>projectToRedirectOutput</name>
     <organization>projecttoredirectoutput</organization>

--- a/extractor/src/test/data/0.13/multiple/structure-0.13.0.xml
+++ b/extractor/src/test/data/0.13/multiple/structure-0.13.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.0">
   <project>
-    <id>root</id>
+    <id>root:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>
@@ -123,7 +123,7 @@
       <classes>$BASE/target/scala-2.10/test-classes</classes>
     </configuration>
     <dependencies>
-      <project configurations="">bar</project>
+      <project configurations="">bar:$URI_BASE</project>
       <module configurations="compile" organization="org.scala-lang" name="scala-library" revision="2.10.1" artifactType="jar" classifier=""/>
     </dependencies>
     <resolver name="public" root="http://repo1.maven.org/maven2/"/>
@@ -1537,7 +1537,7 @@
     </command>
   </project>
   <project>
-    <id>bar</id>
+    <id>bar:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>bar</name>
     <organization>bar</organization>
@@ -3072,7 +3072,7 @@
     </command>
   </project>
   <project>
-    <id>foo</id>
+    <id>foo:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>foo</name>
     <organization>foo</organization>

--- a/extractor/src/test/data/0.13/multiple/structure-0.13.13.xml
+++ b/extractor/src/test/data/0.13/multiple/structure-0.13.13.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.13">
   <project>
-    <id>root</id>
+    <id>root:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>
@@ -149,7 +149,7 @@
       <classes>$BASE/target/scala-2.10/test-classes</classes>
     </configuration>
     <dependencies>
-      <project configurations="">bar</project>
+      <project configurations="">bar:$URI_BASE</project>
       <module configurations="compile" organization="org.scala-lang" name="scala-library" revision="2.10.1" artifactType="jar" classifier=""/>
     </dependencies>
     <resolver name="public" root="https://repo1.maven.org/maven2/"/>
@@ -1764,7 +1764,7 @@
     </command>
   </project>
   <project>
-    <id>bar</id>
+    <id>bar:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>bar</name>
     <organization>bar</organization>
@@ -3526,7 +3526,7 @@
     </command>
   </project>
   <project>
-    <id>foo</id>
+    <id>foo:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>foo</name>
     <organization>foo</organization>

--- a/extractor/src/test/data/0.13/multiple/structure-0.13.9.xml
+++ b/extractor/src/test/data/0.13/multiple/structure-0.13.9.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.9">
   <project>
-    <id>root</id>
+    <id>root:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>
@@ -144,7 +144,7 @@
       <classes>$BASE/target/scala-2.10/test-classes</classes>
     </configuration>
     <dependencies>
-      <project configurations="">bar</project>
+      <project configurations="">bar:$URI_BASE</project>
       <module configurations="compile" organization="org.scala-lang" name="scala-library" revision="2.10.1" artifactType="jar" classifier=""/>
     </dependencies>
     <resolver name="public" root="https://repo1.maven.org/maven2/"/>
@@ -1706,7 +1706,7 @@
     </command>
   </project>
   <project>
-    <id>bar</id>
+    <id>bar:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>bar</name>
     <organization>bar</organization>
@@ -3410,7 +3410,7 @@
     </command>
   </project>
   <project>
-    <id>foo</id>
+    <id>foo:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>foo</name>
     <organization>foo</organization>

--- a/extractor/src/test/data/0.13/optional/structure-0.13.0.xml
+++ b/extractor/src/test/data/0.13/optional/structure-0.13.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.0">
   <project>
-    <id>optional</id>
+    <id>optional:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>optional</name>
     <organization>default</organization>

--- a/extractor/src/test/data/0.13/optional/structure-0.13.13.xml
+++ b/extractor/src/test/data/0.13/optional/structure-0.13.13.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.13">
   <project>
-    <id>optional</id>
+    <id>optional:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>optional</name>
     <organization>default</organization>

--- a/extractor/src/test/data/0.13/optional/structure-0.13.9.xml
+++ b/extractor/src/test/data/0.13/optional/structure-0.13.9.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.9">
   <project>
-    <id>optional</id>
+    <id>optional:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>optional</name>
     <organization>default</organization>

--- a/extractor/src/test/data/0.13/play/structure-0.13.13.xml
+++ b/extractor/src/test/data/0.13/play/structure-0.13.13.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.13">
   <project>
-    <id>root</id>
+    <id>root:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>my-first-app</name>
     <organization>my-first-app</organization>

--- a/extractor/src/test/data/0.13/play/structure-0.13.9.xml
+++ b/extractor/src/test/data/0.13/play/structure-0.13.9.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.9">
   <project>
-    <id>root</id>
+    <id>root:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>my-first-app</name>
     <organization>my-first-app</organization>

--- a/extractor/src/test/data/0.13/sbt-idea/structure-0.13.0.xml
+++ b/extractor/src/test/data/0.13/sbt-idea/structure-0.13.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.0">
   <project>
-    <id>sbtIdea</id>
+    <id>sbtIdea:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/sbt-idea/structure-0.13.13.xml
+++ b/extractor/src/test/data/0.13/sbt-idea/structure-0.13.13.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.13">
   <project>
-    <id>sbtIdea</id>
+    <id>sbtIdea:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/sbt-idea/structure-0.13.9.xml
+++ b/extractor/src/test/data/0.13/sbt-idea/structure-0.13.9.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.9">
   <project>
-    <id>sbtIdea</id>
+    <id>sbtIdea:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/simple/structure-0.13.0.xml
+++ b/extractor/src/test/data/0.13/simple/structure-0.13.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.0">
   <project>
-    <id>simple</id>
+    <id>simple:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/simple/structure-0.13.13.xml
+++ b/extractor/src/test/data/0.13/simple/structure-0.13.13.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.13">
   <project>
-    <id>simple</id>
+    <id>simple:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/data/0.13/simple/structure-0.13.9.xml
+++ b/extractor/src/test/data/0.13/simple/structure-0.13.9.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <structure sbt="0.13.9">
   <project>
-    <id>simple</id>
+    <id>simple:$URI_BASE</id>
     <buildURI>$URI_BASE</buildURI>
     <name>some-name</name>
     <organization>some-organization</organization>

--- a/extractor/src/test/scala/org/jetbrains/sbt/extractors/DependenciesExtractorSpec.scala
+++ b/extractor/src/test/scala/org/jetbrains/sbt/extractors/DependenciesExtractorSpec.scala
@@ -22,7 +22,7 @@ class DependenciesExtractorSpec extends Specification {
 
       val expected = DependencyData(
         projects = Seq(
-          ProjectDependencyData(projects(1).id, Seq(jb.Configuration.Compile))
+          ProjectDependencyData(ExtractorUtils.extractId(projects(1)), Seq(jb.Configuration.Compile))
         ),
         modules = Nil,
         jars = Nil)
@@ -46,7 +46,7 @@ class DependenciesExtractorSpec extends Specification {
 
       val expected = DependencyData(
         projects = Seq(
-          ProjectDependencyData(projects(1).id, Seq(jb.Configuration.Compile))
+          ProjectDependencyData(ExtractorUtils.extractId(projects(1)), Seq(jb.Configuration.Compile))
         ),
         modules = Nil,
         jars = Seq(
@@ -78,7 +78,7 @@ class DependenciesExtractorSpec extends Specification {
 
       val expected = DependencyData(
         projects = Seq(
-          ProjectDependencyData(projects(1).id, Seq(jb.Configuration.Compile))
+          ProjectDependencyData(ExtractorUtils.extractId(projects(1)), Seq(jb.Configuration.Compile))
         ),
         modules = Seq(
           ModuleDependencyData(toIdentifier(moduleId("foo")), Seq(jb.Configuration.Compile)),
@@ -110,7 +110,7 @@ class DependenciesExtractorSpec extends Specification {
 
       val expected = DependencyData(
         projects = Seq(
-          ProjectDependencyData(projects(1).id, Seq(jb.Configuration.Compile))
+          ProjectDependencyData(ExtractorUtils.extractId(projects(1)), Seq(jb.Configuration.Compile))
         ),
         modules = Seq(
           ModuleDependencyData(toIdentifier(moduleId("baz")), Seq(jb.Configuration.Test)),
@@ -144,7 +144,7 @@ class DependenciesExtractorSpec extends Specification {
       val expectedModules = Seq(toIdentifier(moduleId), toIdentifier(moduleId).copy(classifier = "tests"))
       val expected = DependencyData(
         projects = Seq(
-          ProjectDependencyData(projects(1).id, Seq(jb.Configuration.Compile))
+          ProjectDependencyData(ExtractorUtils.extractId(projects(1)), Seq(jb.Configuration.Compile))
         ),
         modules = expectedModules.map(it => ModuleDependencyData(it, Seq(jb.Configuration.Compile))),
         jars = Nil
@@ -173,7 +173,7 @@ class DependenciesExtractorSpec extends Specification {
 
       val expected = DependencyData(
         projects = Seq(
-          ProjectDependencyData(projects(1).id, Seq(jb.Configuration.Compile))
+          ProjectDependencyData(ExtractorUtils.extractId(projects(1)), Seq(jb.Configuration.Compile))
         ),
         modules = Seq(
           ModuleDependencyData(toIdentifier(moduleId), Seq(jb.Configuration.Compile))
@@ -203,7 +203,7 @@ class DependenciesExtractorSpec extends Specification {
 
       val expected = DependencyData(
         projects = Seq(
-          ProjectDependencyData(projects(1).id, Seq(jb.Configuration.Compile))
+          ProjectDependencyData(ExtractorUtils.extractId(projects(1)), Seq(jb.Configuration.Compile))
         ),
         modules = Seq(
           ModuleDependencyData(toIdentifier(moduleId), Seq(jb.Configuration.Provided))


### PR DESCRIPTION
As described on the ticket, having only the SBT project ID as project/module ID, does not guarantee it will be unique when you have sub-projects, cause all sub projects can have the same SBT project ID (e.g. all as "root")

This PR change the project/module ID to be composed by the SBT project ID + project path/URL
### Example:
**SBT project ID**: root
**project URL**: ssh://my-github-repo

**Project/Module ID**: root:ssh://my-github-repo