### PR TITLE
Remove insertProjectTransitiveDependencies setting

### DIFF
--- a/extractor/src/main/scala/org/jetbrains/sbt/Options.scala
+++ b/extractor/src/main/scala/org/jetbrains/sbt/Options.scala
@@ -5,7 +5,6 @@ final case class Options(download: Boolean = false,
                          resolveJavadocClassifiers: Boolean = false,
                          resolveSbtClassifiers: Boolean = false,
                          prettyPrint: Boolean = false,
-                         insertProjectTransitiveDependencies: Boolean = true,
                          separateProdAndTestSources: Boolean = false)
 
 object Options {
@@ -27,7 +26,6 @@ object Options {
     resolveJavadocClassifiers = options.contains(Keys.ResolveJavadocClassifiers),
     resolveSbtClassifiers = options.contains(Keys.ResolveSbtClassifiers),
     prettyPrint = options.contains(Keys.PrettyPrint),
-    insertProjectTransitiveDependencies = options.contains(Keys.InsertProjectTransitiveDependencies),
     separateProdAndTestSources = options.contains(Keys.SeparateProdAndTestSources)
   )
 
@@ -37,7 +35,6 @@ object Options {
     val ResolveJavadocClassifiers = "resolveJavadocClassifiers"
     val ResolveSbtClassifiers = "resolveSbtClassifiers"
     val PrettyPrint = "prettyPrint"
-    val InsertProjectTransitiveDependencies = "insertProjectTransitiveDependencies"
     val SeparateProdAndTestSources = "separateProdAndTestSources"
   }
 }

--- a/extractor/src/test/data/0.13/multiple/structure.xml
+++ b/extractor/src/test/data/0.13/multiple/structure.xml
@@ -155,7 +155,7 @@
       <projects>
         <forTest/>
         <forProduction>
-          <project buildURI="$URI_BASE" configurations="">bar</project>
+          <project buildURI="$URI_BASE" configurations="compile">bar</project>
         </forProduction>
       </projects>
       <modules>

--- a/extractor/src/test/scala/org/jetbrains/sbt/extractors/DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled.scala
+++ b/extractor/src/test/scala/org/jetbrains/sbt/extractors/DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled.scala
@@ -5,8 +5,7 @@ import org.jetbrains.sbt.extractors.DependenciesExtractor.ProductionType
 import org.jetbrains.sbt.structure.*
 import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.must.Matchers.{contain, convertToAnyMustWrapper}
-import sbt.{Attributed, Configuration as SbtConfiguration, globFilter as _, *}
-import sbt.jetbrains.apiAdapter
+import sbt.{Configuration => SbtConfiguration, Attributed, globFilter as _, *}
 
 import scala.collection.Seq
 
@@ -17,19 +16,11 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
   }
   val emptyClasspath: sbt.Configuration => Keys.Classpath = _ => Nil
   val CustomConf = config("custom-conf").extend(sbt.Test)
-  // note: when prod/test sources are enabled, then in DependenciesExtractor#extract
-  // buildDependencies are not used at all, so it can simply be empty
-  val buildDependencies = apiAdapter.buildDependencies(
-    Map.empty,
-    Map.empty
-  )
 
   "DependenciesExtractor for managed and unmanaged dependencies" - {
 
     "always extract unmanaged dependencies" in {
       val actual = new DependenciesExtractor(
-        projects.head,
-        buildDependencies = buildDependencies,
         unmanagedClasspath = Map(
           sbt.Compile -> Seq(
             attributed(file("foo.jar")),
@@ -41,7 +32,6 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
         dependencyConfigurations = Seq(sbt.Compile, sbt.Test),
         testConfigurations = Seq(sbt.Test),
         sourceConfigurations = Seq(sbt.Compile, sbt.Runtime),
-        insertProjectTransitiveDependencies = true,
         separateProdTestSources = true,
         projectToConfigurations = Map(
           ProductionType(projects(1)) -> Seq(Configuration.Test),
@@ -83,8 +73,6 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
       val moduleId = (name: String) => ModuleID("com.example", name, "SNAPSHOT")
 
       val actual = new DependenciesExtractor(
-        projects.head,
-        buildDependencies = buildDependencies,
         unmanagedClasspath = emptyClasspath,
         externalDependencyClasspath = Some(
           Map(
@@ -100,7 +88,6 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
         dependencyConfigurations = Seq(sbt.Compile, sbt.Test),
         testConfigurations = Seq(sbt.Test),
         sourceConfigurations = Seq(sbt.Compile, sbt.Runtime),
-        insertProjectTransitiveDependencies = true,
         separateProdTestSources = true,
         projectToConfigurations = Map(
           ProductionType(projects(1)) -> Seq(Configuration.Test),
@@ -152,8 +139,6 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
       val moduleId = (name: String) => ModuleID("com.example", name, "SNAPSHOT")
 
       val actual = new DependenciesExtractor(
-        projects.head,
-        buildDependencies = buildDependencies,
         unmanagedClasspath = Map(
           sbt.Test -> Seq(attributed(file("foo.jar"))),
           CustomConf -> Seq(attributed(file("bar.jar")))
@@ -171,7 +156,6 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
         dependencyConfigurations = Seq(sbt.Test, CustomConf),
         testConfigurations = Seq(sbt.Test, CustomConf),
         sourceConfigurations = Seq(sbt.Compile, sbt.Runtime),
-        insertProjectTransitiveDependencies = true,
         separateProdTestSources = true,
         projectToConfigurations = Map(
           ProductionType(projects(1)) -> Seq(Configuration.Test),
@@ -224,8 +208,6 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
       val moduleId = "com.example" % "foo" % "SNAPSHOT"
 
       val actual = new DependenciesExtractor(
-        projects.head,
-        buildDependencies = buildDependencies,
         unmanagedClasspath = emptyClasspath,
         externalDependencyClasspath = Some(Map(
           sbt.Compile -> Seq(
@@ -239,7 +221,6 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
         dependencyConfigurations = Seq(sbt.Compile),
         testConfigurations = Seq.empty,
         sourceConfigurations = Seq(sbt.Compile, sbt.Runtime),
-        insertProjectTransitiveDependencies = true,
         separateProdTestSources = true,
         projectToConfigurations = Map(
           ProductionType(projects(1)) -> Seq(Configuration.Test),
@@ -282,8 +263,6 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
       val moduleId = "com.example" % "foo" % "SNAPSHOT"
 
       val actual = new DependenciesExtractor(
-        projects.head,
-        buildDependencies = buildDependencies,
         unmanagedClasspath = Map(
           sbt.Compile -> Seq(attributed(file("bar.jar"))),
           sbt.Test -> Seq(attributed(file("bar.jar"))),
@@ -305,7 +284,6 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
         dependencyConfigurations = Seq(sbt.Compile, sbt.Test, sbt.Runtime),
         testConfigurations = Seq.empty,
         sourceConfigurations = Seq(sbt.Compile, sbt.Runtime),
-        insertProjectTransitiveDependencies = true,
         separateProdTestSources = true,
         projectToConfigurations = Map(
           ProductionType(projects(1)) -> Seq(Configuration.Compile, Configuration.Test, Configuration.Runtime),
@@ -371,8 +349,6 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
       val moduleId = "com.example" % "foo" % "SNAPSHOT"
 
       val actual = new DependenciesExtractor(
-        projects.head,
-        buildDependencies = buildDependencies,
         unmanagedClasspath = Map(
           sbt.Compile -> Seq(attributed(file("bar.jar"))),
           sbt.Test -> Seq(attributed(file("bar.jar"))),
@@ -392,7 +368,6 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
         dependencyConfigurations = Seq(sbt.Compile, sbt.Test, sbt.Runtime),
         testConfigurations = Seq.empty,
         sourceConfigurations = Seq(sbt.Compile, sbt.Runtime),
-        insertProjectTransitiveDependencies = true,
         separateProdTestSources = true,
         projectToConfigurations = Map(
           ProductionType(projects(1)) -> Seq(Configuration.Test, Configuration.Compile),
@@ -458,8 +433,6 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
       val moduleId = "com.example" % "foo" % "SNAPSHOT"
 
       val actual =  new DependenciesExtractor(
-        projects.head,
-        buildDependencies,
         unmanagedClasspath = Map(
           sbt.Compile -> Seq(attributed(file("bar.jar"))),
           CustomConf -> Seq(attributed(file("bar.jar"))),
@@ -481,7 +454,6 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
         dependencyConfigurations = Seq(sbt.Compile, sbt.Test, sbt.Runtime, CustomConf),
         testConfigurations = Seq(sbt.Test, CustomConf),
         sourceConfigurations = Seq(sbt.Compile, sbt.Runtime),
-        insertProjectTransitiveDependencies = true,
         separateProdTestSources = true,
         projectToConfigurations = Map(
           ProductionType(projects(1)) -> Seq(Configuration.Compile, Configuration(CustomConf.name)),


### PR DESCRIPTION
- from now on, project transitive dependencies are enabled by default, and it's not possible to switch it off