### PR TITLE
fix constructor syntax

### DIFF
--- a/extractor/src/main/scala/org/jetbrains/sbt/adapters.scala
+++ b/extractor/src/main/scala/org/jetbrains/sbt/adapters.scala
@@ -17,7 +17,7 @@ case class LoadedBuildUnitAdapter(delegate: LoadedBuildUnit) {
 }
 
 case class UpdateReportAdapter(configurationToModule: Map[String, Seq[ModuleReportAdapter]]) {
-  def this(delegate: UpdateReport) {
+  def this(delegate: UpdateReport) = {
     this(delegate.configurations.map { report =>
       (configReportName(report), report.modules.map(new ModuleReportAdapter(_)))
     }.toMap)
@@ -31,7 +31,7 @@ case class UpdateReportAdapter(configurationToModule: Map[String, Seq[ModuleRepo
 }
 
 case class ModuleReportAdapter(moduleId: ModuleID, artifacts: Seq[(Artifact, File)]) {
-  def this(delegate: ModuleReport) {
+  def this(delegate: ModuleReport) = {
     this(delegate.module, delegate.artifacts)
   }
 }


### PR DESCRIPTION
prepare Scala 3, sbt 2.x cross build

```
Welcome to Scala 2.13.15 (OpenJDK 64-Bit Server VM, Java 21.0.4).
Type in expressions for evaluation. Or try :help.

scala> class A {
     |   def this(x: Int) { this() }
     | }
         def this(x: Int) { this() }
                         ^
On line 2: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition [quickfixable]
```

```
Welcome to Scala 3.3.4 (21.0.4, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                             
scala> class A {
     |   def this(x: Int) { this() }
-- [E040] Syntax Error: --------------------------------------------------------
2 |  def this(x: Int) { this() }
  |                   ^
  |                   '=' expected, but '{' found
```