### PR TITLE
use `scala.reflect.ClassTag` instead of deprecated `Manifest`

### DIFF
--- a/shared/src/main/scala/org/jetbrains/sbt/structure/XmlSerializer.scala
+++ b/shared/src/main/scala/org/jetbrains/sbt/structure/XmlSerializer.scala
@@ -1,6 +1,7 @@
 package org.jetbrains.sbt
 package structure
 
+import scala.reflect.ClassTag
 import scala.xml._
 
 /**
@@ -22,12 +23,12 @@ object XmlSerializer {
     def deserialize[T](implicit serializer: XmlSerializer[T]): Seq[T] =
       nodeSeq.flatMap(_.deserialize[T].fold(_ => None, x => Some(x)))
 
-    def deserializeOne[T](implicit serializer: XmlSerializer[T], manifest: Manifest[T]): Either[Throwable,T] = {
+    def deserializeOne[T](implicit serializer: XmlSerializer[T], manifest: ClassTag[T]): Either[Throwable,T] = {
       val ts = nodeSeq.map(_.deserialize[T]).collect { case Right(t) => t }
       if (ts.isEmpty)
-        Left(new Error("None of " + manifest.erasure.getSimpleName + " is found in " + nodeSeq))
+        Left(new Error("None of " + manifest.runtimeClass.getSimpleName + " is found in " + nodeSeq))
       else if (ts.length > 1)
-        Left(new Error("Multiple instances of " + manifest.erasure.getSimpleName + " are found in " + nodeSeq))
+        Left(new Error("Multiple instances of " + manifest.runtimeClass.getSimpleName + " are found in " + nodeSeq))
       else
         Right(ts.head)
     }


### PR DESCRIPTION
```
$ scala -deprecation
Welcome to Scala 3.3.4 (21.0.4, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                             
scala> implicitly[Manifest[Int]]
1 warning found
-- Deprecation Warning: --------------------------------------------------------
1 |implicitly[Manifest[Int]]
  |                         ^
  |Compiler synthesis of Manifest and OptManifest is deprecated, instead
  |replace with the type `scala.reflect.ClassTag[Int]`.
  |Alternatively, consider using the new metaprogramming features of Scala 3,
  |see https://docs.scala-lang.org/scala3/reference/metaprogramming.html
val res0: Manifest[Int] = Int
                                                                                                                                             
scala> implicitly[scala.reflect.ClassTag[Int]]
val res1: scala.reflect.ClassTag[Int] = Int
```