### PR TITLE
Maintain the classpath order when the main/test modules mode is enabled

### DIFF
--- a/extractor/src/test/data/1.9/dependency_resolve_sbt_classifiers_prod_test_sources_separated/structure.xml
+++ b/extractor/src/test/data/1.9/dependency_resolve_sbt_classifiers_prod_test_sources_separated/structure.xml
@@ -313,8 +313,8 @@
       </projects>
       <modules>
         <forTest>
-          <module configurations="compile" organization="junit" name="junit" revision="4.13.2" artifactType="jar" classifier=""/>
           <module configurations="compile" organization="org.scala-lang" name="scala-library" revision="2.10.1" artifactType="jar" classifier=""/>
+          <module configurations="compile" organization="junit" name="junit" revision="4.13.2" artifactType="jar" classifier=""/>
           <module configurations="compile" organization="org.hamcrest" name="hamcrest-core" revision="1.3" artifactType="jar" classifier=""/>
         </forTest>
         <forProduction>

--- a/extractor/src/test/data/2.0/simple/structure.xml
+++ b/extractor/src/test/data/2.0/simple/structure.xml
@@ -207,12 +207,12 @@
       <modules>
         <forTest>
           <module configurations="compile" organization="org.scala-lang" name="scala3-library_3" revision="3.6.2" artifactType="jar" classifier=""/>
-          <module configurations="compile" organization="org.hamcrest" name="hamcrest-core" revision="1.3" artifactType="jar" classifier=""/>
+          <module configurations="compile" organization="org.scalameta" name="munit_3" revision="0.7.29" artifactType="jar" classifier=""/>
+          <module configurations="compile" organization="org.scala-lang" name="scala-library" revision="2.13.15" artifactType="jar" classifier=""/>
+          <module configurations="compile" organization="org.scalameta" name="junit-interface" revision="0.7.29" artifactType="jar" classifier=""/>
           <module configurations="compile" organization="junit" name="junit" revision="4.13.2" artifactType="jar" classifier=""/>
           <module configurations="compile" organization="org.scala-sbt" name="test-interface" revision="1.0" artifactType="jar" classifier=""/>
-          <module configurations="compile" organization="org.scalameta" name="junit-interface" revision="0.7.29" artifactType="jar" classifier=""/>
-          <module configurations="compile" organization="org.scala-lang" name="scala-library" revision="2.13.15" artifactType="jar" classifier=""/>
-          <module configurations="compile" organization="org.scalameta" name="munit_3" revision="0.7.29" artifactType="jar" classifier=""/>
+          <module configurations="compile" organization="org.hamcrest" name="hamcrest-core" revision="1.3" artifactType="jar" classifier=""/>
         </forTest>
         <forProduction>
           <module configurations="compile" organization="org.scala-lang" name="scala3-library_3" revision="3.6.2" artifactType="jar" classifier=""/>

--- a/extractor/src/test/scala/org/jetbrains/sbt/extractors/DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled.scala
+++ b/extractor/src/test/scala/org/jetbrains/sbt/extractors/DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled.scala
@@ -217,9 +217,10 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
               Artifact("foo", "tests")
             )
           ),
+          sbt.Test -> Seq.empty
         )),
-        dependencyConfigurations = Seq(sbt.Compile),
-        testConfigurations = Seq.empty,
+        dependencyConfigurations = Seq(sbt.Compile, sbt.Test),
+        testConfigurations = Seq(sbt.Test),
         sourceConfigurations = Seq(sbt.Compile, sbt.Runtime),
         separateProdTestSources = true,
         projectToConfigurations = Map(
@@ -282,7 +283,7 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
           ).apply
         ),
         dependencyConfigurations = Seq(sbt.Compile, sbt.Test, sbt.Runtime),
-        testConfigurations = Seq.empty,
+        testConfigurations = Seq(sbt.Test),
         sourceConfigurations = Seq(sbt.Compile, sbt.Runtime),
         separateProdTestSources = true,
         projectToConfigurations = Map(
@@ -366,7 +367,7 @@ class DependenciesExtractorSpec_ProdTestSourcesSeparatedEnabled extends AnyFreeS
           ).apply
         ),
         dependencyConfigurations = Seq(sbt.Compile, sbt.Test, sbt.Runtime),
-        testConfigurations = Seq.empty,
+        testConfigurations = Seq(sbt.Test),
         sourceConfigurations = Seq(sbt.Compile, sbt.Runtime),
         separateProdTestSources = true,
         projectToConfigurations = Map(


### PR DESCRIPTION
This is the fix for https://youtrack.jetbrains.com/issue/SCL-23845/Create-separate-modules-for-production-and-test-sources-option-leads-to-dependency-collision