### PR TITLE
SCL-23856 - Generate managed sources during project sync

### DIFF
--- a/extractor-legacy-0.13/src/main/scala/org/jetbrains/sbt/StructureKeys.scala
+++ b/extractor-legacy-0.13/src/main/scala/org/jetbrains/sbt/StructureKeys.scala
@@ -29,6 +29,7 @@ object StructureKeys {
   val sbtStructureOpts: SettingKey[Options] = SettingKey("ssOptions", "options for dumpStructure task", rank = DSetting)
   val sbtStructureOptions: SettingKey[String] = SettingKey("sbtStructureOptions", "options for dumpStructure task as string", rank = DSetting)
   val sbtStructureOutputFile: SettingKey[Option[File]] = SettingKey("sbtStructureOutputFile", "output file for dumpStructure task",rank = DSetting)
+  val generateManagedSourcesDuringStructureDump: SettingKey[Boolean] = SettingKey("generateManagedSourcesDuringStructureDump", "generate managed sources during dumpStructure task", rank = DSetting)
 
   val loadOptions: TaskKey[Options] = TaskKey("ssLoadOptions", "load options from ssOptionsFile if available", rank = Invisible)
   val dumpStructure: TaskKey[Unit] = TaskKey("dumpStructure", "dump project structure to XML readable by IntelliJ", rank = DTask)

--- a/extractor-legacy-0.13/src/main/scala/org/jetbrains/sbt/StructurePlugin.scala
+++ b/extractor-legacy-0.13/src/main/scala/org/jetbrains/sbt/StructurePlugin.scala
@@ -16,7 +16,8 @@ object StructurePlugin extends AutoPlugin {
   override lazy val globalSettings: Seq[Setting[_]] = Seq(
     StructureKeys.sbtStructureOutputFile := None,
     StructureKeys.sbtStructureOptions := "prettyPrint download",
-    StructureKeys.dumpStructureTo := pluginOnlyTasks.dumpStructureTo.evaluated
+    StructureKeys.dumpStructureTo := pluginOnlyTasks.dumpStructureTo.evaluated,
+    StructureKeys.generateManagedSourcesDuringStructureDump := true
   ) ++ CreateTasks.globalSettings
 
   override lazy val projectSettings: Seq[Setting[_]] = CreateTasks.projectSettings

--- a/extractor/src/main/scala/org/jetbrains/sbt/StructureKeys.scala
+++ b/extractor/src/main/scala/org/jetbrains/sbt/StructureKeys.scala
@@ -33,6 +33,7 @@ object StructureKeys {
   val sbtStructureOpts: SettingKey[Options] = SettingKey("ssOptions", "options for dumpStructure task", rank = DSetting)
   val sbtStructureOptions: SettingKey[String] = SettingKey("sbtStructureOptions", "options for dumpStructure task as string", rank = DSetting)
   val sbtStructureOutputFile: SettingKey[Option[File]] = SettingKey("sbtStructureOutputFile", "output file for dumpStructure task",rank = DSetting)
+  val generateManagedSourcesDuringStructureDump: SettingKey[Boolean] = SettingKey("generateManagedSourcesDuringStructureDump", "generate managed sources during dumpStructure task", rank = DSetting)
 
   val loadOptions: TaskKey[Options] = TaskKey("ssLoadOptions", "load options from ssOptionsFile if available", rank = Invisible)
   val dumpStructure: TaskKey[Unit] = TaskKey("dumpStructure", "dump project structure to XML readable by IntelliJ", rank = DTask)

--- a/extractor/src/main/scala/org/jetbrains/sbt/StructurePlugin.scala
+++ b/extractor/src/main/scala/org/jetbrains/sbt/StructurePlugin.scala
@@ -14,7 +14,8 @@ object StructurePlugin extends AutoPlugin {
   override lazy val globalSettings: Seq[Setting[?]] = Seq(
     StructureKeys.sbtStructureOutputFile := None,
     StructureKeys.sbtStructureOptions := "prettyPrint download",
-    StructureKeys.dumpStructureTo := PluginOnlyTasksCompat.dumpStructureTo.evaluated
+    StructureKeys.dumpStructureTo := PluginOnlyTasksCompat.dumpStructureTo.evaluated,
+    StructureKeys.generateManagedSourcesDuringStructureDump := true
   ) ++ CreateTasks.globalSettings
 
   override lazy val projectSettings: Seq[Setting[?]] = CreateTasks.projectSettings.toSbtSeqType

--- a/extractor/src/test/scala/org/jetbrains/sbt/integrationTests/utils/SbtStructureLoader.scala
+++ b/extractor/src/test/scala/org/jetbrains/sbt/integrationTests/utils/SbtStructureLoader.scala
@@ -20,6 +20,7 @@ object SbtStructureLoader {
     val sbtCommands: Seq[String] = Seq(
       s"""set ${scopedSbtSetting("""SettingKey[Option[File]]("sbtStructureOutputFile")""", "Global", sbtVersion)} := Some(file("${path(structureFile)}"))""",
       s"""set ${scopedSbtSetting("""SettingKey[String]("sbtStructureOptions")""", "Global", sbtVersion)} := "$sbtStructureOptionsPatched"""",
+      s"""set ${scopedSbtSetting("""SettingKey[Boolean]("generateManagedSourcesDuringStructureDump")""", "Global", sbtVersion)} := true""",
       s"""apply -cp ${path(pluginFile)} org.jetbrains.sbt.CreateTasks""",
       s"""dumpStructure"""
     )


### PR DESCRIPTION
Generate managed sources during the execution of the structure dump task.
https://youtrack.jetbrains.com/issue/SCL-23856/SBT-ability-to-auto-generate-managed-sources-during-project-reload