### PR TITLE
[build] Disable the parallel execution of tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -194,6 +194,7 @@ lazy val extractor = project.in(file("extractor"))
       else
         Nil
     },
+    Test / parallelExecution := false
   )
 
 // We use separate module for 0.13 with many sources duplicated as an alternative to cross-compilation.


### PR DESCRIPTION
- It's possible for the tests to contend over the global `~/.sbt-structure-global` directory when it comes to resolving dependencies because separate independent instances of sbt are running in different integration test suites.