### PR TITLE
Run tests against sbt 1.12.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     name: sbt-structure plugin Build & Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: actions/setup-java@v5
       with:
         distribution: temurin

--- a/extractor/src/test/data/1.12/auto-scala-library-disabled/structure.xml
+++ b/extractor/src/test/data/1.12/auto-scala-library-disabled/structure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<structure sbt="1.12.12">
+<structure sbt="1.12.13">
   <build>
     <uri>$URI_BASE</uri>
     <import>import _root_.sbt.Keys._</import>
@@ -12,89 +12,89 @@
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-library.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-reflect.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/actions_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/caffeine-2.8.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/checker-qual-3.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/collections_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/command_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-bridge_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-interface-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/completion_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/config-1.4.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/core-macros_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/disruptor-3.4.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/error_prone_annotations-2.4.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/file-tree-views-2.1.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-apache-http_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-core_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/io_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ipcsocket-1.6.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jansi-2.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-builtins-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-native-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-reader-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-style-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-jni-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-platform-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jsch-2.27.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/launcher-interface-1.6.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-core_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-ivy_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/lm-coursier-shaded_2.12-2.1.13.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-api-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-core-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-slf4j-impl-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/logic_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main-settings_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/protocol_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/reactive-streams-1.0.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/run_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbinary_2.12-0.5.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbt-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-collection-compat_2.12-2.14.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-compiler-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-library-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-parser-combinators_2.12-1.1.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-reflect-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scripted-plugin_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-apache-httpclient5-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-jawn-parser_2.12-1.3.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-core_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-scalajson_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/slf4j-api-1.7.36.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ssl-config-core_2.12-0.7.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/task-system_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/tasks_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/template-resolver-0.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-agent-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-interface-1.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/testing_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-cache_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-control_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-interface-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-logging_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-position_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-relation_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-tracking_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zero-allocation-hashing-0.16.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-apiinfo_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classfile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classpath_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-lm-integration_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist-core-assembly-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/actions_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/caffeine-2.8.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/checker-qual-3.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/collections_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/command_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-bridge_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-interface-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/completion_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/config-1.4.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/core-macros_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/disruptor-3.4.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/error_prone_annotations-2.4.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/file-tree-views-2.1.12.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-apache-http_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-core_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/io_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ipcsocket-1.7.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jansi-2.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-builtins-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-native-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-reader-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-style-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-jni-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-platform-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jsch-2.27.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/launcher-interface-1.6.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-core_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-ivy_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/lm-coursier-shaded_2.12-2.1.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-api-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-core-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-slf4j-impl-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/logic_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main-settings_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/protocol_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/reactive-streams-1.0.3.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/run_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbinary_2.12-0.5.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbt-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-collection-compat_2.12-2.14.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-compiler-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-library-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-parser-combinators_2.12-1.1.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-reflect-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-xml_2.12-2.3.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scripted-plugin_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-apache-httpclient5-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-jawn-parser_2.12-1.3.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-core_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-scalajson_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/slf4j-api-1.7.36.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ssl-config-core_2.12-0.7.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/task-system_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/tasks_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/template-resolver-0.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-agent-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-interface-1.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/testing_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-cache_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-control_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-interface-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-logging_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-position_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-relation_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-tracking_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zero-allocation-hashing-0.16.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-apiinfo_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classfile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classpath_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-lm-integration_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist-core-assembly-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc_2.12-1.12.0.jar</classes>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-apache-http_2.12/0.9.4/gigahorse-apache-http_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-core_2.12/0.9.4/gigahorse-core_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/shaded-apache-httpclient5/0.9.4/shaded-apache-httpclient5-0.9.4-sources.jar</sources>
@@ -132,48 +132,48 @@
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.21/scala-compiler-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.21/scala-library-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.21/scala-reflect-2.12.21-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.12/actions_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.12/collections_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.12/command_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.13/actions_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.13/collections_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.13/command_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.12/1.12.0/compiler-bridge_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.12.0/compiler-interface-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.12/completion_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.12/core-macros_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.0/io_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.6.3/ipcsocket-1.6.3-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.13/completion_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.13/core-macros_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.2/io_2.12-1.12.2-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.7.0/ipcsocket-1.7.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ivy/ivy/2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/jline/jline/2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/launcher-interface/1.6.1/launcher-interface-1.6.1-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-core_2.12/1.12.2/librarymanagement-core_2.12-1.12.2-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-ivy_2.12/1.12.2/librarymanagement-ivy_2.12-1.12.2-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.12/logic_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.12/main-settings_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.12/main_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.12/protocol_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.12/run_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.13/logic_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.13/main-settings_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.13/main_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.13/protocol_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.13/run_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.5.1/sbinary_2.12-0.5.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.12/sbt-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.12/scripted-plugin_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.12/task-system_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.12/tasks_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.13/sbt-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.13/scripted-plugin_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.13/task-system_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.13/tasks_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/template-resolver/0.1/template-resolver-0.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.12/test-agent-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.13/test-agent-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.12/testing_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.12/util-cache_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.12/util-control_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.12/util-interface-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.12/util-logging_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.12/util-position_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.12/util-relation_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.12/util-tracking_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.13/testing_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.13/util-cache_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.13/util-control_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.13/util-interface-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.13/util-logging_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.13/util-position_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.13/util-relation_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.13/util-tracking_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-apiinfo_2.12/1.12.0/zinc-apiinfo_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classfile_2.12/1.12.0/zinc-classfile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classpath_2.12/1.12.0/zinc-classpath_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile-core_2.12/1.12.0/zinc-compile-core_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile_2.12/1.12.0/zinc-compile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-core_2.12/1.12.0/zinc-core_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.12/zinc-lm-integration_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.13/zinc-lm-integration_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist-core-assembly/1.12.0/zinc-persist-core-assembly-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist_2.12/1.12.0/zinc-persist_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc_2.12/1.12.0/zinc_2.12-1.12.0-sources.jar</sources>

--- a/extractor/src/test/data/1.12/buildinfo/structure.xml
+++ b/extractor/src/test/data/1.12/buildinfo/structure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<structure sbt="1.12.12">
+<structure sbt="1.12.13">
   <build>
     <uri>$URI_BASE</uri>
     <import>import $MachineSpecificHexString.`buildinfo`</import>
@@ -13,89 +13,89 @@
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-library.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-reflect.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/actions_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/caffeine-2.8.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/checker-qual-3.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/collections_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/command_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-bridge_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-interface-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/completion_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/config-1.4.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/core-macros_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/disruptor-3.4.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/error_prone_annotations-2.4.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/file-tree-views-2.1.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-apache-http_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-core_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/io_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ipcsocket-1.6.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jansi-2.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-builtins-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-native-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-reader-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-style-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-jni-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-platform-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jsch-2.27.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/launcher-interface-1.6.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-core_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-ivy_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/lm-coursier-shaded_2.12-2.1.13.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-api-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-core-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-slf4j-impl-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/logic_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main-settings_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/protocol_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/reactive-streams-1.0.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/run_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbinary_2.12-0.5.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbt-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-collection-compat_2.12-2.14.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-compiler-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-library-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-parser-combinators_2.12-1.1.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-reflect-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scripted-plugin_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-apache-httpclient5-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-jawn-parser_2.12-1.3.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-core_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-scalajson_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/slf4j-api-1.7.36.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ssl-config-core_2.12-0.7.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/task-system_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/tasks_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/template-resolver-0.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-agent-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-interface-1.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/testing_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-cache_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-control_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-interface-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-logging_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-position_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-relation_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-tracking_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zero-allocation-hashing-0.16.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-apiinfo_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classfile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classpath_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-lm-integration_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist-core-assembly-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/actions_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/caffeine-2.8.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/checker-qual-3.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/collections_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/command_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-bridge_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-interface-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/completion_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/config-1.4.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/core-macros_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/disruptor-3.4.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/error_prone_annotations-2.4.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/file-tree-views-2.1.12.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-apache-http_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-core_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/io_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ipcsocket-1.7.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jansi-2.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-builtins-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-native-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-reader-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-style-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-jni-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-platform-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jsch-2.27.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/launcher-interface-1.6.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-core_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-ivy_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/lm-coursier-shaded_2.12-2.1.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-api-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-core-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-slf4j-impl-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/logic_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main-settings_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/protocol_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/reactive-streams-1.0.3.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/run_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbinary_2.12-0.5.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbt-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-collection-compat_2.12-2.14.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-compiler-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-library-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-parser-combinators_2.12-1.1.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-reflect-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-xml_2.12-2.3.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scripted-plugin_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-apache-httpclient5-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-jawn-parser_2.12-1.3.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-core_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-scalajson_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/slf4j-api-1.7.36.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ssl-config-core_2.12-0.7.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/task-system_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/tasks_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/template-resolver-0.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-agent-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-interface-1.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/testing_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-cache_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-control_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-interface-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-logging_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-position_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-relation_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-tracking_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zero-allocation-hashing-0.16.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-apiinfo_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classfile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classpath_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-lm-integration_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist-core-assembly-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc_2.12-1.12.0.jar</classes>
     <classes>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/sbt-buildinfo_2.12_1.0/0.13.1/sbt-buildinfo_2.12_1.0-0.13.1.jar</classes>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-apache-http_2.12/0.9.4/gigahorse-apache-http_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-core_2.12/0.9.4/gigahorse-core_2.12-0.9.4-sources.jar</sources>
@@ -135,48 +135,48 @@
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.21/scala-compiler-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.21/scala-library-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.21/scala-reflect-2.12.21-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.12/actions_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.12/collections_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.12/command_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.13/actions_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.13/collections_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.13/command_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.12/1.12.0/compiler-bridge_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.12.0/compiler-interface-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.12/completion_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.12/core-macros_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.0/io_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.6.3/ipcsocket-1.6.3-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.13/completion_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.13/core-macros_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.2/io_2.12-1.12.2-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.7.0/ipcsocket-1.7.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ivy/ivy/2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/jline/jline/2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/launcher-interface/1.6.1/launcher-interface-1.6.1-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-core_2.12/1.12.2/librarymanagement-core_2.12-1.12.2-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-ivy_2.12/1.12.2/librarymanagement-ivy_2.12-1.12.2-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.12/logic_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.12/main-settings_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.12/main_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.12/protocol_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.12/run_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.13/logic_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.13/main-settings_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.13/main_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.13/protocol_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.13/run_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.5.1/sbinary_2.12-0.5.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.12/sbt-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.12/scripted-plugin_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.12/task-system_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.12/tasks_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.13/sbt-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.13/scripted-plugin_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.13/task-system_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.13/tasks_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/template-resolver/0.1/template-resolver-0.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.12/test-agent-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.13/test-agent-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.12/testing_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.12/util-cache_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.12/util-control_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.12/util-interface-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.12/util-logging_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.12/util-position_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.12/util-relation_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.12/util-tracking_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.13/testing_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.13/util-cache_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.13/util-control_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.13/util-interface-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.13/util-logging_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.13/util-position_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.13/util-relation_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.13/util-tracking_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-apiinfo_2.12/1.12.0/zinc-apiinfo_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classfile_2.12/1.12.0/zinc-classfile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classpath_2.12/1.12.0/zinc-classpath_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile-core_2.12/1.12.0/zinc-compile-core_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile_2.12/1.12.0/zinc-compile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-core_2.12/1.12.0/zinc-core_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.12/zinc-lm-integration_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.13/zinc-lm-integration_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist-core-assembly/1.12.0/zinc-persist-core-assembly-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist_2.12/1.12.0/zinc-persist_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc_2.12/1.12.0/zinc_2.12-1.12.0-sources.jar</sources>

--- a/extractor/src/test/data/1.12/custom-source-generator/structure.xml
+++ b/extractor/src/test/data/1.12/custom-source-generator/structure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<structure sbt="1.12.12">
+<structure sbt="1.12.13">
   <build>
     <uri>$URI_BASE</uri>
     <import>import $MachineSpecificHexString.`module1`</import>
@@ -17,89 +17,89 @@
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-library.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-reflect.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/actions_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/caffeine-2.8.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/checker-qual-3.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/collections_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/command_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-bridge_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-interface-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/completion_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/config-1.4.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/core-macros_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/disruptor-3.4.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/error_prone_annotations-2.4.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/file-tree-views-2.1.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-apache-http_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-core_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/io_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ipcsocket-1.6.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jansi-2.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-builtins-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-native-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-reader-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-style-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-jni-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-platform-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jsch-2.27.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/launcher-interface-1.6.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-core_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-ivy_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/lm-coursier-shaded_2.12-2.1.13.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-api-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-core-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-slf4j-impl-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/logic_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main-settings_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/protocol_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/reactive-streams-1.0.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/run_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbinary_2.12-0.5.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbt-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-collection-compat_2.12-2.14.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-compiler-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-library-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-parser-combinators_2.12-1.1.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-reflect-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scripted-plugin_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-apache-httpclient5-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-jawn-parser_2.12-1.3.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-core_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-scalajson_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/slf4j-api-1.7.36.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ssl-config-core_2.12-0.7.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/task-system_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/tasks_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/template-resolver-0.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-agent-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-interface-1.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/testing_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-cache_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-control_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-interface-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-logging_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-position_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-relation_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-tracking_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zero-allocation-hashing-0.16.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-apiinfo_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classfile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classpath_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-lm-integration_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist-core-assembly-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/actions_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/caffeine-2.8.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/checker-qual-3.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/collections_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/command_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-bridge_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-interface-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/completion_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/config-1.4.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/core-macros_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/disruptor-3.4.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/error_prone_annotations-2.4.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/file-tree-views-2.1.12.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-apache-http_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-core_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/io_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ipcsocket-1.7.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jansi-2.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-builtins-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-native-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-reader-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-style-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-jni-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-platform-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jsch-2.27.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/launcher-interface-1.6.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-core_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-ivy_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/lm-coursier-shaded_2.12-2.1.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-api-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-core-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-slf4j-impl-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/logic_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main-settings_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/protocol_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/reactive-streams-1.0.3.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/run_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbinary_2.12-0.5.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbt-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-collection-compat_2.12-2.14.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-compiler-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-library-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-parser-combinators_2.12-1.1.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-reflect-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-xml_2.12-2.3.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scripted-plugin_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-apache-httpclient5-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-jawn-parser_2.12-1.3.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-core_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-scalajson_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/slf4j-api-1.7.36.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ssl-config-core_2.12-0.7.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/task-system_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/tasks_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/template-resolver-0.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-agent-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-interface-1.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/testing_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-cache_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-control_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-interface-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-logging_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-position_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-relation_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-tracking_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zero-allocation-hashing-0.16.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-apiinfo_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classfile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classpath_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-lm-integration_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist-core-assembly-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc_2.12-1.12.0.jar</classes>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-apache-http_2.12/0.9.4/gigahorse-apache-http_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-core_2.12/0.9.4/gigahorse-core_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/shaded-apache-httpclient5/0.9.4/shaded-apache-httpclient5-0.9.4-sources.jar</sources>
@@ -137,48 +137,48 @@
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.21/scala-compiler-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.21/scala-library-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.21/scala-reflect-2.12.21-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.12/actions_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.12/collections_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.12/command_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.13/actions_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.13/collections_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.13/command_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.12/1.12.0/compiler-bridge_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.12.0/compiler-interface-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.12/completion_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.12/core-macros_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.0/io_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.6.3/ipcsocket-1.6.3-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.13/completion_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.13/core-macros_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.2/io_2.12-1.12.2-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.7.0/ipcsocket-1.7.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ivy/ivy/2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/jline/jline/2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/launcher-interface/1.6.1/launcher-interface-1.6.1-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-core_2.12/1.12.2/librarymanagement-core_2.12-1.12.2-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-ivy_2.12/1.12.2/librarymanagement-ivy_2.12-1.12.2-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.12/logic_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.12/main-settings_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.12/main_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.12/protocol_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.12/run_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.13/logic_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.13/main-settings_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.13/main_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.13/protocol_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.13/run_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.5.1/sbinary_2.12-0.5.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.12/sbt-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.12/scripted-plugin_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.12/task-system_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.12/tasks_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.13/sbt-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.13/scripted-plugin_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.13/task-system_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.13/tasks_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/template-resolver/0.1/template-resolver-0.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.12/test-agent-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.13/test-agent-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.12/testing_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.12/util-cache_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.12/util-control_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.12/util-interface-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.12/util-logging_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.12/util-position_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.12/util-relation_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.12/util-tracking_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.13/testing_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.13/util-cache_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.13/util-control_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.13/util-interface-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.13/util-logging_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.13/util-position_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.13/util-relation_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.13/util-tracking_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-apiinfo_2.12/1.12.0/zinc-apiinfo_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classfile_2.12/1.12.0/zinc-classfile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classpath_2.12/1.12.0/zinc-classpath_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile-core_2.12/1.12.0/zinc-compile-core_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile_2.12/1.12.0/zinc-compile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-core_2.12/1.12.0/zinc-core_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.12/zinc-lm-integration_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.13/zinc-lm-integration_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist-core-assembly/1.12.0/zinc-persist-core-assembly-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist_2.12/1.12.0/zinc-persist_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc_2.12/1.12.0/zinc_2.12-1.12.0-sources.jar</sources>

--- a/extractor/src/test/data/1.12/kotlinc-options/structure.xml
+++ b/extractor/src/test/data/1.12/kotlinc-options/structure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<structure sbt="1.12.12">
+<structure sbt="1.12.13">
   <build>
     <uri>$URI_BASE</uri>
     <import>import $MachineSpecificHexString.`kotlincOptions`</import>
@@ -13,89 +13,89 @@
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-library.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-reflect.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/actions_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/caffeine-2.8.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/checker-qual-3.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/collections_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/command_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-bridge_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-interface-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/completion_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/config-1.4.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/core-macros_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/disruptor-3.4.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/error_prone_annotations-2.4.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/file-tree-views-2.1.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-apache-http_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-core_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/io_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ipcsocket-1.6.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jansi-2.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-builtins-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-native-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-reader-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-style-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-jni-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-platform-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jsch-2.27.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/launcher-interface-1.6.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-core_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-ivy_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/lm-coursier-shaded_2.12-2.1.13.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-api-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-core-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-slf4j-impl-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/logic_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main-settings_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/protocol_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/reactive-streams-1.0.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/run_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbinary_2.12-0.5.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbt-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-collection-compat_2.12-2.14.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-compiler-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-library-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-parser-combinators_2.12-1.1.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-reflect-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scripted-plugin_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-apache-httpclient5-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-jawn-parser_2.12-1.3.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-core_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-scalajson_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/slf4j-api-1.7.36.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ssl-config-core_2.12-0.7.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/task-system_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/tasks_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/template-resolver-0.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-agent-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-interface-1.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/testing_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-cache_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-control_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-interface-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-logging_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-position_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-relation_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-tracking_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zero-allocation-hashing-0.16.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-apiinfo_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classfile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classpath_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-lm-integration_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist-core-assembly-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/actions_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/caffeine-2.8.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/checker-qual-3.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/collections_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/command_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-bridge_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-interface-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/completion_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/config-1.4.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/core-macros_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/disruptor-3.4.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/error_prone_annotations-2.4.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/file-tree-views-2.1.12.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-apache-http_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-core_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/io_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ipcsocket-1.7.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jansi-2.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-builtins-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-native-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-reader-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-style-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-jni-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-platform-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jsch-2.27.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/launcher-interface-1.6.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-core_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-ivy_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/lm-coursier-shaded_2.12-2.1.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-api-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-core-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-slf4j-impl-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/logic_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main-settings_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/protocol_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/reactive-streams-1.0.3.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/run_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbinary_2.12-0.5.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbt-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-collection-compat_2.12-2.14.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-compiler-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-library-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-parser-combinators_2.12-1.1.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-reflect-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-xml_2.12-2.3.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scripted-plugin_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-apache-httpclient5-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-jawn-parser_2.12-1.3.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-core_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-scalajson_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/slf4j-api-1.7.36.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ssl-config-core_2.12-0.7.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/task-system_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/tasks_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/template-resolver-0.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-agent-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-interface-1.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/testing_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-cache_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-control_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-interface-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-logging_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-position_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-relation_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-tracking_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zero-allocation-hashing-0.16.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-apiinfo_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classfile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classpath_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-lm-integration_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist-core-assembly-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc_2.12-1.12.0.jar</classes>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-apache-http_2.12/0.9.4/gigahorse-apache-http_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-core_2.12/0.9.4/gigahorse-core_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/shaded-apache-httpclient5/0.9.4/shaded-apache-httpclient5-0.9.4-sources.jar</sources>
@@ -133,48 +133,48 @@
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.21/scala-compiler-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.21/scala-library-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.21/scala-reflect-2.12.21-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.12/actions_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.12/collections_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.12/command_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.13/actions_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.13/collections_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.13/command_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.12/1.12.0/compiler-bridge_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.12.0/compiler-interface-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.12/completion_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.12/core-macros_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.0/io_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.6.3/ipcsocket-1.6.3-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.13/completion_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.13/core-macros_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.2/io_2.12-1.12.2-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.7.0/ipcsocket-1.7.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ivy/ivy/2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/jline/jline/2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/launcher-interface/1.6.1/launcher-interface-1.6.1-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-core_2.12/1.12.2/librarymanagement-core_2.12-1.12.2-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-ivy_2.12/1.12.2/librarymanagement-ivy_2.12-1.12.2-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.12/logic_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.12/main-settings_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.12/main_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.12/protocol_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.12/run_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.13/logic_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.13/main-settings_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.13/main_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.13/protocol_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.13/run_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.5.1/sbinary_2.12-0.5.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.12/sbt-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.12/scripted-plugin_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.12/task-system_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.12/tasks_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.13/sbt-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.13/scripted-plugin_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.13/task-system_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.13/tasks_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/template-resolver/0.1/template-resolver-0.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.12/test-agent-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.13/test-agent-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.12/testing_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.12/util-cache_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.12/util-control_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.12/util-interface-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.12/util-logging_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.12/util-position_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.12/util-relation_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.12/util-tracking_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.13/testing_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.13/util-cache_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.13/util-control_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.13/util-interface-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.13/util-logging_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.13/util-position_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.13/util-relation_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.13/util-tracking_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-apiinfo_2.12/1.12.0/zinc-apiinfo_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classfile_2.12/1.12.0/zinc-classfile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classpath_2.12/1.12.0/zinc-classpath_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile-core_2.12/1.12.0/zinc-compile-core_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile_2.12/1.12.0/zinc-compile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-core_2.12/1.12.0/zinc-core_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.12/zinc-lm-integration_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.13/zinc-lm-integration_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist-core-assembly/1.12.0/zinc-persist-core-assembly-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist_2.12/1.12.0/zinc-persist_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc_2.12/1.12.0/zinc_2.12-1.12.0-sources.jar</sources>

--- a/extractor/src/test/data/1.12/maanged-scala-auto-scala-library-disabled/structure.xml
+++ b/extractor/src/test/data/1.12/maanged-scala-auto-scala-library-disabled/structure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<structure sbt="1.12.12">
+<structure sbt="1.12.13">
   <build>
     <uri>$URI_BASE</uri>
     <import>import _root_.sbt.Keys._</import>
@@ -12,89 +12,89 @@
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-library.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-reflect.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/actions_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/caffeine-2.8.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/checker-qual-3.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/collections_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/command_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-bridge_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-interface-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/completion_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/config-1.4.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/core-macros_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/disruptor-3.4.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/error_prone_annotations-2.4.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/file-tree-views-2.1.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-apache-http_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-core_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/io_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ipcsocket-1.6.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jansi-2.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-builtins-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-native-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-reader-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-style-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-jni-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-platform-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jsch-2.27.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/launcher-interface-1.6.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-core_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-ivy_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/lm-coursier-shaded_2.12-2.1.13.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-api-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-core-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-slf4j-impl-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/logic_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main-settings_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/protocol_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/reactive-streams-1.0.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/run_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbinary_2.12-0.5.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbt-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-collection-compat_2.12-2.14.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-compiler-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-library-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-parser-combinators_2.12-1.1.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-reflect-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scripted-plugin_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-apache-httpclient5-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-jawn-parser_2.12-1.3.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-core_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-scalajson_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/slf4j-api-1.7.36.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ssl-config-core_2.12-0.7.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/task-system_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/tasks_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/template-resolver-0.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-agent-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-interface-1.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/testing_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-cache_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-control_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-interface-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-logging_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-position_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-relation_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-tracking_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zero-allocation-hashing-0.16.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-apiinfo_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classfile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classpath_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-lm-integration_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist-core-assembly-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/actions_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/caffeine-2.8.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/checker-qual-3.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/collections_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/command_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-bridge_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-interface-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/completion_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/config-1.4.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/core-macros_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/disruptor-3.4.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/error_prone_annotations-2.4.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/file-tree-views-2.1.12.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-apache-http_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-core_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/io_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ipcsocket-1.7.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jansi-2.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-builtins-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-native-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-reader-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-style-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-jni-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-platform-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jsch-2.27.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/launcher-interface-1.6.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-core_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-ivy_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/lm-coursier-shaded_2.12-2.1.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-api-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-core-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-slf4j-impl-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/logic_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main-settings_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/protocol_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/reactive-streams-1.0.3.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/run_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbinary_2.12-0.5.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbt-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-collection-compat_2.12-2.14.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-compiler-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-library-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-parser-combinators_2.12-1.1.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-reflect-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-xml_2.12-2.3.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scripted-plugin_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-apache-httpclient5-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-jawn-parser_2.12-1.3.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-core_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-scalajson_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/slf4j-api-1.7.36.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ssl-config-core_2.12-0.7.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/task-system_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/tasks_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/template-resolver-0.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-agent-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-interface-1.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/testing_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-cache_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-control_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-interface-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-logging_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-position_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-relation_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-tracking_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zero-allocation-hashing-0.16.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-apiinfo_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classfile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classpath_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-lm-integration_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist-core-assembly-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc_2.12-1.12.0.jar</classes>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-apache-http_2.12/0.9.4/gigahorse-apache-http_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-core_2.12/0.9.4/gigahorse-core_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/shaded-apache-httpclient5/0.9.4/shaded-apache-httpclient5-0.9.4-sources.jar</sources>
@@ -132,48 +132,48 @@
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.21/scala-compiler-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.21/scala-library-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.21/scala-reflect-2.12.21-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.12/actions_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.12/collections_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.12/command_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.13/actions_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.13/collections_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.13/command_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.12/1.12.0/compiler-bridge_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.12.0/compiler-interface-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.12/completion_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.12/core-macros_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.0/io_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.6.3/ipcsocket-1.6.3-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.13/completion_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.13/core-macros_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.2/io_2.12-1.12.2-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.7.0/ipcsocket-1.7.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ivy/ivy/2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/jline/jline/2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/launcher-interface/1.6.1/launcher-interface-1.6.1-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-core_2.12/1.12.2/librarymanagement-core_2.12-1.12.2-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-ivy_2.12/1.12.2/librarymanagement-ivy_2.12-1.12.2-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.12/logic_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.12/main-settings_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.12/main_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.12/protocol_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.12/run_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.13/logic_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.13/main-settings_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.13/main_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.13/protocol_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.13/run_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.5.1/sbinary_2.12-0.5.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.12/sbt-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.12/scripted-plugin_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.12/task-system_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.12/tasks_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.13/sbt-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.13/scripted-plugin_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.13/task-system_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.13/tasks_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/template-resolver/0.1/template-resolver-0.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.12/test-agent-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.13/test-agent-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.12/testing_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.12/util-cache_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.12/util-control_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.12/util-interface-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.12/util-logging_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.12/util-position_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.12/util-relation_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.12/util-tracking_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.13/testing_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.13/util-cache_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.13/util-control_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.13/util-interface-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.13/util-logging_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.13/util-position_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.13/util-relation_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.13/util-tracking_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-apiinfo_2.12/1.12.0/zinc-apiinfo_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classfile_2.12/1.12.0/zinc-classfile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classpath_2.12/1.12.0/zinc-classpath_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile-core_2.12/1.12.0/zinc-compile-core_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile_2.12/1.12.0/zinc-compile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-core_2.12/1.12.0/zinc-core_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.12/zinc-lm-integration_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.13/zinc-lm-integration_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist-core-assembly/1.12.0/zinc-persist-core-assembly-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist_2.12/1.12.0/zinc-persist_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc_2.12/1.12.0/zinc_2.12-1.12.0-sources.jar</sources>

--- a/extractor/src/test/data/1.12/missing-scala-library-jar/structure.xml
+++ b/extractor/src/test/data/1.12/missing-scala-library-jar/structure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<structure sbt="1.12.12">
+<structure sbt="1.12.13">
   <build>
     <uri>$URI_BASE</uri>
     <import>import _root_.sbt.Keys._</import>
@@ -12,89 +12,89 @@
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-library.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-reflect.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/actions_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/caffeine-2.8.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/checker-qual-3.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/collections_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/command_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-bridge_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-interface-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/completion_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/config-1.4.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/core-macros_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/disruptor-3.4.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/error_prone_annotations-2.4.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/file-tree-views-2.1.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-apache-http_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-core_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/io_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ipcsocket-1.6.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jansi-2.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-builtins-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-native-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-reader-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-style-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-jni-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-platform-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jsch-2.27.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/launcher-interface-1.6.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-core_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-ivy_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/lm-coursier-shaded_2.12-2.1.13.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-api-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-core-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-slf4j-impl-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/logic_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main-settings_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/protocol_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/reactive-streams-1.0.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/run_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbinary_2.12-0.5.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbt-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-collection-compat_2.12-2.14.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-compiler-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-library-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-parser-combinators_2.12-1.1.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-reflect-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scripted-plugin_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-apache-httpclient5-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-jawn-parser_2.12-1.3.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-core_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-scalajson_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/slf4j-api-1.7.36.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ssl-config-core_2.12-0.7.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/task-system_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/tasks_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/template-resolver-0.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-agent-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-interface-1.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/testing_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-cache_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-control_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-interface-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-logging_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-position_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-relation_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-tracking_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zero-allocation-hashing-0.16.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-apiinfo_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classfile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classpath_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-lm-integration_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist-core-assembly-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/actions_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/caffeine-2.8.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/checker-qual-3.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/collections_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/command_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-bridge_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-interface-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/completion_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/config-1.4.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/core-macros_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/disruptor-3.4.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/error_prone_annotations-2.4.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/file-tree-views-2.1.12.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-apache-http_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-core_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/io_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ipcsocket-1.7.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jansi-2.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-builtins-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-native-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-reader-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-style-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-jni-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-platform-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jsch-2.27.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/launcher-interface-1.6.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-core_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-ivy_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/lm-coursier-shaded_2.12-2.1.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-api-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-core-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-slf4j-impl-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/logic_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main-settings_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/protocol_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/reactive-streams-1.0.3.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/run_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbinary_2.12-0.5.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbt-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-collection-compat_2.12-2.14.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-compiler-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-library-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-parser-combinators_2.12-1.1.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-reflect-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-xml_2.12-2.3.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scripted-plugin_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-apache-httpclient5-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-jawn-parser_2.12-1.3.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-core_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-scalajson_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/slf4j-api-1.7.36.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ssl-config-core_2.12-0.7.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/task-system_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/tasks_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/template-resolver-0.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-agent-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-interface-1.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/testing_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-cache_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-control_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-interface-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-logging_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-position_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-relation_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-tracking_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zero-allocation-hashing-0.16.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-apiinfo_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classfile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classpath_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-lm-integration_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist-core-assembly-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc_2.12-1.12.0.jar</classes>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-apache-http_2.12/0.9.4/gigahorse-apache-http_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-core_2.12/0.9.4/gigahorse-core_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/shaded-apache-httpclient5/0.9.4/shaded-apache-httpclient5-0.9.4-sources.jar</sources>
@@ -132,48 +132,48 @@
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.21/scala-compiler-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.21/scala-library-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.21/scala-reflect-2.12.21-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.12/actions_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.12/collections_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.12/command_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.13/actions_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.13/collections_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.13/command_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.12/1.12.0/compiler-bridge_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.12.0/compiler-interface-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.12/completion_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.12/core-macros_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.0/io_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.6.3/ipcsocket-1.6.3-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.13/completion_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.13/core-macros_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.2/io_2.12-1.12.2-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.7.0/ipcsocket-1.7.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ivy/ivy/2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/jline/jline/2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/launcher-interface/1.6.1/launcher-interface-1.6.1-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-core_2.12/1.12.2/librarymanagement-core_2.12-1.12.2-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-ivy_2.12/1.12.2/librarymanagement-ivy_2.12-1.12.2-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.12/logic_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.12/main-settings_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.12/main_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.12/protocol_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.12/run_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.13/logic_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.13/main-settings_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.13/main_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.13/protocol_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.13/run_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.5.1/sbinary_2.12-0.5.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.12/sbt-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.12/scripted-plugin_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.12/task-system_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.12/tasks_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.13/sbt-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.13/scripted-plugin_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.13/task-system_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.13/tasks_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/template-resolver/0.1/template-resolver-0.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.12/test-agent-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.13/test-agent-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.12/testing_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.12/util-cache_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.12/util-control_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.12/util-interface-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.12/util-logging_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.12/util-position_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.12/util-relation_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.12/util-tracking_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.13/testing_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.13/util-cache_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.13/util-control_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.13/util-interface-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.13/util-logging_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.13/util-position_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.13/util-relation_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.13/util-tracking_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-apiinfo_2.12/1.12.0/zinc-apiinfo_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classfile_2.12/1.12.0/zinc-classfile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classpath_2.12/1.12.0/zinc-classpath_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile-core_2.12/1.12.0/zinc-compile-core_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile_2.12/1.12.0/zinc-compile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-core_2.12/1.12.0/zinc-core_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.12/zinc-lm-integration_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.13/zinc-lm-integration_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist-core-assembly/1.12.0/zinc-persist-core-assembly-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist_2.12/1.12.0/zinc-persist_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc_2.12/1.12.0/zinc_2.12-1.12.0-sources.jar</sources>

--- a/extractor/src/test/data/1.12/missing-scala-tool-config/structure.xml
+++ b/extractor/src/test/data/1.12/missing-scala-tool-config/structure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<structure sbt="1.12.12">
+<structure sbt="1.12.13">
   <build>
     <uri>$URI_BASE</uri>
     <import>import _root_.sbt.Keys._</import>
@@ -12,89 +12,89 @@
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-library.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-reflect.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/actions_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/caffeine-2.8.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/checker-qual-3.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/collections_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/command_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-bridge_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-interface-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/completion_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/config-1.4.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/core-macros_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/disruptor-3.4.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/error_prone_annotations-2.4.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/file-tree-views-2.1.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-apache-http_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-core_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/io_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ipcsocket-1.6.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jansi-2.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-builtins-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-native-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-reader-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-style-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-jni-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-platform-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jsch-2.27.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/launcher-interface-1.6.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-core_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-ivy_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/lm-coursier-shaded_2.12-2.1.13.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-api-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-core-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-slf4j-impl-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/logic_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main-settings_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/protocol_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/reactive-streams-1.0.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/run_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbinary_2.12-0.5.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbt-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-collection-compat_2.12-2.14.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-compiler-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-library-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-parser-combinators_2.12-1.1.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-reflect-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scripted-plugin_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-apache-httpclient5-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-jawn-parser_2.12-1.3.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-core_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-scalajson_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/slf4j-api-1.7.36.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ssl-config-core_2.12-0.7.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/task-system_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/tasks_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/template-resolver-0.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-agent-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-interface-1.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/testing_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-cache_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-control_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-interface-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-logging_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-position_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-relation_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-tracking_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zero-allocation-hashing-0.16.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-apiinfo_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classfile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classpath_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-lm-integration_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist-core-assembly-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/actions_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/caffeine-2.8.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/checker-qual-3.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/collections_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/command_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-bridge_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-interface-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/completion_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/config-1.4.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/core-macros_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/disruptor-3.4.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/error_prone_annotations-2.4.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/file-tree-views-2.1.12.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-apache-http_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-core_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/io_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ipcsocket-1.7.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jansi-2.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-builtins-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-native-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-reader-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-style-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-jni-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-platform-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jsch-2.27.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/launcher-interface-1.6.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-core_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-ivy_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/lm-coursier-shaded_2.12-2.1.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-api-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-core-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-slf4j-impl-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/logic_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main-settings_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/protocol_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/reactive-streams-1.0.3.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/run_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbinary_2.12-0.5.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbt-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-collection-compat_2.12-2.14.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-compiler-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-library-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-parser-combinators_2.12-1.1.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-reflect-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-xml_2.12-2.3.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scripted-plugin_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-apache-httpclient5-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-jawn-parser_2.12-1.3.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-core_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-scalajson_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/slf4j-api-1.7.36.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ssl-config-core_2.12-0.7.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/task-system_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/tasks_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/template-resolver-0.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-agent-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-interface-1.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/testing_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-cache_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-control_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-interface-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-logging_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-position_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-relation_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-tracking_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zero-allocation-hashing-0.16.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-apiinfo_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classfile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classpath_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-lm-integration_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist-core-assembly-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc_2.12-1.12.0.jar</classes>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-apache-http_2.12/0.9.4/gigahorse-apache-http_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-core_2.12/0.9.4/gigahorse-core_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/shaded-apache-httpclient5/0.9.4/shaded-apache-httpclient5-0.9.4-sources.jar</sources>
@@ -132,48 +132,48 @@
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.21/scala-compiler-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.21/scala-library-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.21/scala-reflect-2.12.21-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.12/actions_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.12/collections_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.12/command_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.13/actions_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.13/collections_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.13/command_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.12/1.12.0/compiler-bridge_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.12.0/compiler-interface-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.12/completion_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.12/core-macros_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.0/io_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.6.3/ipcsocket-1.6.3-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.13/completion_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.13/core-macros_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.2/io_2.12-1.12.2-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.7.0/ipcsocket-1.7.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ivy/ivy/2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/jline/jline/2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/launcher-interface/1.6.1/launcher-interface-1.6.1-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-core_2.12/1.12.2/librarymanagement-core_2.12-1.12.2-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-ivy_2.12/1.12.2/librarymanagement-ivy_2.12-1.12.2-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.12/logic_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.12/main-settings_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.12/main_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.12/protocol_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.12/run_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.13/logic_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.13/main-settings_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.13/main_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.13/protocol_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.13/run_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.5.1/sbinary_2.12-0.5.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.12/sbt-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.12/scripted-plugin_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.12/task-system_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.12/tasks_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.13/sbt-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.13/scripted-plugin_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.13/task-system_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.13/tasks_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/template-resolver/0.1/template-resolver-0.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.12/test-agent-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.13/test-agent-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.12/testing_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.12/util-cache_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.12/util-control_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.12/util-interface-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.12/util-logging_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.12/util-position_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.12/util-relation_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.12/util-tracking_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.13/testing_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.13/util-cache_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.13/util-control_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.13/util-interface-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.13/util-logging_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.13/util-position_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.13/util-relation_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.13/util-tracking_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-apiinfo_2.12/1.12.0/zinc-apiinfo_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classfile_2.12/1.12.0/zinc-classfile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classpath_2.12/1.12.0/zinc-classpath_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile-core_2.12/1.12.0/zinc-compile-core_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile_2.12/1.12.0/zinc-compile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-core_2.12/1.12.0/zinc-core_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.12/zinc-lm-integration_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.13/zinc-lm-integration_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist-core-assembly/1.12.0/zinc-persist-core-assembly-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist_2.12/1.12.0/zinc-persist_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc_2.12/1.12.0/zinc_2.12-1.12.0-sources.jar</sources>

--- a/extractor/src/test/data/1.12/source-generator-failure/structure.xml
+++ b/extractor/src/test/data/1.12/source-generator-failure/structure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<structure sbt="1.12.12">
+<structure sbt="1.12.13">
   <build>
     <uri>$URI_BASE</uri>
     <import>import $MachineSpecificHexString.`module1`</import>
@@ -17,89 +17,89 @@
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-library.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-reflect.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/actions_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/caffeine-2.8.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/checker-qual-3.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/collections_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/command_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-bridge_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-interface-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/completion_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/config-1.4.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/core-macros_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/disruptor-3.4.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/error_prone_annotations-2.4.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/file-tree-views-2.1.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-apache-http_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-core_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/io_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ipcsocket-1.6.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jansi-2.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-builtins-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-native-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-reader-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-style-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-jni-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-platform-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jsch-2.27.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/launcher-interface-1.6.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-core_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-ivy_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/lm-coursier-shaded_2.12-2.1.13.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-api-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-core-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-slf4j-impl-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/logic_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main-settings_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/protocol_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/reactive-streams-1.0.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/run_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbinary_2.12-0.5.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbt-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-collection-compat_2.12-2.14.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-compiler-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-library-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-parser-combinators_2.12-1.1.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-reflect-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scripted-plugin_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-apache-httpclient5-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-jawn-parser_2.12-1.3.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-core_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-scalajson_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/slf4j-api-1.7.36.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ssl-config-core_2.12-0.7.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/task-system_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/tasks_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/template-resolver-0.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-agent-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-interface-1.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/testing_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-cache_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-control_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-interface-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-logging_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-position_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-relation_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-tracking_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zero-allocation-hashing-0.16.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-apiinfo_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classfile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classpath_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-lm-integration_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist-core-assembly-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/actions_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/caffeine-2.8.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/checker-qual-3.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/collections_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/command_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-bridge_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-interface-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/completion_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/config-1.4.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/core-macros_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/disruptor-3.4.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/error_prone_annotations-2.4.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/file-tree-views-2.1.12.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-apache-http_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-core_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/io_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ipcsocket-1.7.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jansi-2.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-builtins-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-native-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-reader-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-style-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-jni-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-platform-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jsch-2.27.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/launcher-interface-1.6.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-core_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-ivy_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/lm-coursier-shaded_2.12-2.1.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-api-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-core-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-slf4j-impl-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/logic_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main-settings_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/protocol_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/reactive-streams-1.0.3.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/run_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbinary_2.12-0.5.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbt-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-collection-compat_2.12-2.14.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-compiler-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-library-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-parser-combinators_2.12-1.1.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-reflect-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-xml_2.12-2.3.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scripted-plugin_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-apache-httpclient5-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-jawn-parser_2.12-1.3.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-core_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-scalajson_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/slf4j-api-1.7.36.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ssl-config-core_2.12-0.7.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/task-system_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/tasks_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/template-resolver-0.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-agent-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-interface-1.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/testing_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-cache_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-control_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-interface-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-logging_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-position_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-relation_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-tracking_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zero-allocation-hashing-0.16.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-apiinfo_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classfile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classpath_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-lm-integration_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist-core-assembly-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc_2.12-1.12.0.jar</classes>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-apache-http_2.12/0.9.4/gigahorse-apache-http_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-core_2.12/0.9.4/gigahorse-core_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/shaded-apache-httpclient5/0.9.4/shaded-apache-httpclient5-0.9.4-sources.jar</sources>
@@ -137,48 +137,48 @@
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.21/scala-compiler-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.21/scala-library-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.21/scala-reflect-2.12.21-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.12/actions_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.12/collections_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.12/command_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.13/actions_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.13/collections_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.13/command_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.12/1.12.0/compiler-bridge_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.12.0/compiler-interface-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.12/completion_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.12/core-macros_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.0/io_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.6.3/ipcsocket-1.6.3-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.13/completion_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.13/core-macros_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.2/io_2.12-1.12.2-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.7.0/ipcsocket-1.7.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ivy/ivy/2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/jline/jline/2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/launcher-interface/1.6.1/launcher-interface-1.6.1-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-core_2.12/1.12.2/librarymanagement-core_2.12-1.12.2-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-ivy_2.12/1.12.2/librarymanagement-ivy_2.12-1.12.2-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.12/logic_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.12/main-settings_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.12/main_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.12/protocol_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.12/run_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.13/logic_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.13/main-settings_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.13/main_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.13/protocol_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.13/run_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.5.1/sbinary_2.12-0.5.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.12/sbt-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.12/scripted-plugin_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.12/task-system_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.12/tasks_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.13/sbt-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.13/scripted-plugin_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.13/task-system_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.13/tasks_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/template-resolver/0.1/template-resolver-0.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.12/test-agent-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.13/test-agent-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.12/testing_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.12/util-cache_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.12/util-control_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.12/util-interface-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.12/util-logging_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.12/util-position_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.12/util-relation_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.12/util-tracking_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.13/testing_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.13/util-cache_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.13/util-control_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.13/util-interface-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.13/util-logging_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.13/util-position_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.13/util-relation_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.13/util-tracking_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-apiinfo_2.12/1.12.0/zinc-apiinfo_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classfile_2.12/1.12.0/zinc-classfile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classpath_2.12/1.12.0/zinc-classpath_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile-core_2.12/1.12.0/zinc-compile-core_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile_2.12/1.12.0/zinc-compile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-core_2.12/1.12.0/zinc-core_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.12/zinc-lm-integration_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.13/zinc-lm-integration_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist-core-assembly/1.12.0/zinc-persist-core-assembly-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist_2.12/1.12.0/zinc-persist_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc_2.12/1.12.0/zinc_2.12-1.12.0-sources.jar</sources>

--- a/extractor/src/test/data/1.12/unmanaged-scala-instance-ok/structure.xml
+++ b/extractor/src/test/data/1.12/unmanaged-scala-instance-ok/structure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<structure sbt="1.12.12">
+<structure sbt="1.12.13">
   <build>
     <uri>$URI_BASE</uri>
     <import>import _root_.sbt.Keys._</import>
@@ -12,89 +12,89 @@
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-library.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-reflect.jar</classes>
     <classes>$SBT_BOOT/scala-2.12.21/lib/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/actions_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/caffeine-2.8.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/checker-qual-3.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/collections_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/command_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-bridge_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/compiler-interface-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/completion_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/config-1.4.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/core-macros_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/disruptor-3.4.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/error_prone_annotations-2.4.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/file-tree-views-2.1.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-apache-http_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/gigahorse-core_2.12-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/io_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ipcsocket-1.6.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jansi-2.4.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-builtins-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-native-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-reader-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-style-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jline-terminal-jni-3.27.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jna-platform-5.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/jsch-2.27.5.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/launcher-interface-1.6.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-core_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/librarymanagement-ivy_2.12-1.12.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/lm-coursier-shaded_2.12-2.1.13.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-api-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-core-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/log4j-slf4j-impl-2.25.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/logic_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main-settings_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/main_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/protocol_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/reactive-streams-1.0.3.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/run_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbinary_2.12-0.5.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sbt-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-collection-compat_2.12-2.14.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-compiler-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-library-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-parser-combinators_2.12-1.1.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-reflect-2.12.21.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scala-xml_2.12-2.3.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/scripted-plugin_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-apache-httpclient5-0.9.4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-jawn-parser_2.12-1.3.2.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-core_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/sjson-new-scalajson_2.12-0.10.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/slf4j-api-1.7.36.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/ssl-config-core_2.12-0.7.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/task-system_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/tasks_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/template-resolver-0.1.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-agent-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/test-interface-1.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/testing_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-cache_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-control_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-interface-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-logging_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-position_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-relation_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/util-tracking_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zero-allocation-hashing-0.16.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-apiinfo_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classfile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-classpath_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-compile_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-core_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-lm-integration_2.12-1.12.12.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist-core-assembly-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc-persist_2.12-1.12.0.jar</classes>
-    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.12/zinc_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/actions_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/caffeine-2.8.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/checker-qual-3.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/collections_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/command_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-bridge_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/compiler-interface-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/completion_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/config-1.4.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/core-macros_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/disruptor-3.4.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/error_prone_annotations-2.4.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/file-tree-views-2.1.12.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-apache-http_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/gigahorse-core_2.12-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/io_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ipcsocket-1.7.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jansi-2.4.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-builtins-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-native-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-reader-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-style-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jline-terminal-jni-3.27.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jna-platform-5.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/jsch-2.27.5.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/launcher-interface-1.6.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-core_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/librarymanagement-ivy_2.12-1.12.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/lm-coursier-shaded_2.12-2.1.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-api-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-core-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/log4j-slf4j-impl-2.25.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/logic_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main-settings_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/main_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/protocol_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/reactive-streams-1.0.3.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/run_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbinary_2.12-0.5.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sbt-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-collection-compat_2.12-2.14.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-compiler-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-library-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-parser-combinators_2.12-1.1.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-reflect-2.12.21.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scala-xml_2.12-2.3.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/scripted-plugin_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-apache-httpclient5-0.9.4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-jawn-parser_2.12-1.3.2.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/shaded-scalajson_2.12-1.0.0-M4.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-core_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-murmurhash_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/sjson-new-scalajson_2.12-0.10.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/slf4j-api-1.7.36.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/ssl-config-core_2.12-0.7.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/task-system_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/tasks_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/template-resolver-0.1.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-agent-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/test-interface-1.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/testing_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-cache_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-control_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-interface-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-logging_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-position_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-relation_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/util-tracking_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zero-allocation-hashing-0.16.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-apiinfo_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classfile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-classpath_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-compile_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-core_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-lm-integration_2.12-1.12.13.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist-core-assembly-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc-persist_2.12-1.12.0.jar</classes>
+    <classes>$SBT_BOOT/scala-2.12.21/org.scala-sbt/sbt/1.12.13/zinc_2.12-1.12.0.jar</classes>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-apache-http_2.12/0.9.4/gigahorse-apache-http_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/gigahorse-core_2.12/0.9.4/gigahorse-core_2.12-0.9.4-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/com/eed3si9n/shaded-apache-httpclient5/0.9.4/shaded-apache-httpclient5-0.9.4-sources.jar</sources>
@@ -132,48 +132,48 @@
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.21/scala-compiler-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.21/scala-library-2.12.21-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.21/scala-reflect-2.12.21-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.12/actions_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.12/collections_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.12/command_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/actions_2.12/1.12.13/actions_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/collections_2.12/1.12.13/collections_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/command_2.12/1.12.13/command_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.12/1.12.0/compiler-bridge_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.12.0/compiler-interface-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.12/completion_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.12/core-macros_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.0/io_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.6.3/ipcsocket-1.6.3-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/completion_2.12/1.12.13/completion_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/core-macros_2.12/1.12.13/core-macros_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/io_2.12/1.12.2/io_2.12-1.12.2-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ipcsocket/ipcsocket/1.7.0/ipcsocket-1.7.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/ivy/ivy/2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41/ivy-2.3.0-sbt-77cc781d727b367d3761f097d89f5a4762771d41-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/jline/jline/2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18/jline-2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/launcher-interface/1.6.1/launcher-interface-1.6.1-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-core_2.12/1.12.2/librarymanagement-core_2.12-1.12.2-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/librarymanagement-ivy_2.12/1.12.2/librarymanagement-ivy_2.12-1.12.2-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.12/logic_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.12/main-settings_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.12/main_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.12/protocol_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.12/run_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/logic_2.12/1.12.13/logic_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main-settings_2.12/1.12.13/main-settings_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/main_2.12/1.12.13/main_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/protocol_2.12/1.12.13/protocol_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/run_2.12/1.12.13/run_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.5.1/sbinary_2.12-0.5.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.12/sbt-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.12/scripted-plugin_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.12/task-system_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.12/tasks_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/sbt/1.12.13/sbt-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/scripted-plugin_2.12/1.12.13/scripted-plugin_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/task-system_2.12/1.12.13/task-system_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/tasks_2.12/1.12.13/tasks_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/template-resolver/0.1/template-resolver-0.1-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.12/test-agent-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-agent/1.12.13/test-agent-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.12/testing_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.12/util-cache_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.12/util-control_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.12/util-interface-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.12/util-logging_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.12/util-position_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.12/util-relation_2.12-1.12.12-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.12/util-tracking_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/testing_2.12/1.12.13/testing_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-cache_2.12/1.12.13/util-cache_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-control_2.12/1.12.13/util-control_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.12.13/util-interface-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-logging_2.12/1.12.13/util-logging_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-position_2.12/1.12.13/util-position_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-relation_2.12/1.12.13/util-relation_2.12-1.12.13-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/util-tracking_2.12/1.12.13/util-tracking_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-apiinfo_2.12/1.12.0/zinc-apiinfo_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classfile_2.12/1.12.0/zinc-classfile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-classpath_2.12/1.12.0/zinc-classpath_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile-core_2.12/1.12.0/zinc-compile-core_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-compile_2.12/1.12.0/zinc-compile_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-core_2.12/1.12.0/zinc-core_2.12-1.12.0-sources.jar</sources>
-    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.12/zinc-lm-integration_2.12-1.12.12-sources.jar</sources>
+    <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-lm-integration_2.12/1.12.13/zinc-lm-integration_2.12-1.12.13-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist-core-assembly/1.12.0/zinc-persist-core-assembly-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc-persist_2.12/1.12.0/zinc-persist_2.12-1.12.0-sources.jar</sources>
     <sources>$COURSIER/cache/https/repo1.maven.org/maven2/org/scala-sbt/zinc_2.12/1.12.0/zinc_2.12-1.12.0-sources.jar</sources>

--- a/extractor/src/test/scala/org/jetbrains/sbt/integrationTests/utils/LatestSbtVersions.scala
+++ b/extractor/src/test/scala/org/jetbrains/sbt/integrationTests/utils/LatestSbtVersions.scala
@@ -14,7 +14,7 @@ object LatestSbtVersions {
   val SbtVersion_1_9: Version = Version("1.9.9")
   val SbtVersion_1_10: Version = Version("1.10.11")
   val SbtVersion_1_11: Version = Version("1.11.7")
-  val SbtVersion_1_12: Version = Version("1.12.12")
+  val SbtVersion_1_12: Version = Version("1.12.13")
   val SbtVersion_2_legacy: Version = Version("2.0.0-RC6") // There was a binary breakage regarding `scalaCompilerBridgeBinaryJar` which we work around.
   val SbtVersion_2: Version = Version("2.0.0")
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.12
+sbt.version=1.12.13


### PR DESCRIPTION
## Summary

sbt **1.12.13** was released (latest in the 1.12 series). This updates our test
matrix to run integration tests against it and regenerates the affected expected
test data.

- Bumped `SbtVersion_1_12` from `1.12.12` to `1.12.13` in `LatestSbtVersions.scala`.
- No other sbt versions changed: the older 1.x series remain frozen at their final
  patch releases, `SbtVersion_2` is already at the final `2.0.0`, and
  `SbtVersion_2_legacy` (`2.0.0-RC6`) is intentionally left as-is.

## Regenerated test data

The version bump changes the embedded sbt version in the extracted structure, the
sbt jar paths, and pulls newer sbt transitive dependencies
(`io_2.12` `1.12.0 → 1.12.2`, `ipcsocket` `1.6.3 → 1.7.0`). The following `1.12`
test projects' `structure.xml` files were regenerated to match:

- `auto-scala-library-disabled`
- `buildinfo`
- `custom-source-generator`
- `kotlinc-options`
- `maanged-scala-auto-scala-library-disabled`
- `missing-scala-library-jar`
- `missing-scala-tool-config`
- `source-generator-failure`
- `unmanaged-scala-instance-ok`

## Verification

`sbt --java-home $(java_home -v 17) clean +compile test` — all 189 tests pass.